### PR TITLE
Rename go module from router to matcha

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,3 +40,7 @@ Currently, new submissions to `matcha` are subject to the following criteria:
 2. **Testing**: Test coverage should stay above 95%. New behavior is expected to have associated unit tests
 3. **Documentation**: CloudRETIC strongly encourages detailed documentation of code, and pull requests will be evaluated on quality of comments and external documentation in `/docs`.
 4. **Style**: While style is massively subjective, you should follow good Go code practices. We use [this list](https://github.com/golang/go/wiki/CodeReviewComments#gofmt) to evaluate style.
+
+## Divergent Branches
+
+`main` should not diverge from *future* versions, but may diverge from *past* versions.

--- a/bench/github_test.go
+++ b/bench/github_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	crroute "github.com/cloudretic/router/pkg/route"
-	"github.com/cloudretic/router/pkg/router"
+	crroute "github.com/cloudretic/matcha/pkg/route"
+	"github.com/cloudretic/matcha/pkg/router"
 )
 
 // Benchmark against the GitHub API.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/cloudretic/router
+module github.com/cloudretic/matcha
 
 go 1.20

--- a/pkg/adapter/adapter_test.go
+++ b/pkg/adapter/adapter_test.go
@@ -9,8 +9,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/cloudretic/router/pkg/route"
-	"github.com/cloudretic/router/pkg/router"
+	"github.com/cloudretic/matcha/pkg/route"
+	"github.com/cloudretic/matcha/pkg/router"
 )
 
 /*

--- a/pkg/cors/middleware.go
+++ b/pkg/cors/middleware.go
@@ -3,7 +3,7 @@ package cors
 import (
 	"net/http"
 
-	"github.com/cloudretic/router/pkg/middleware"
+	"github.com/cloudretic/matcha/pkg/middleware"
 )
 
 // CORS middleware

--- a/pkg/route/config.go
+++ b/pkg/route/config.go
@@ -1,8 +1,8 @@
 package route
 
 import (
-	"github.com/cloudretic/router/pkg/cors"
-	"github.com/cloudretic/router/pkg/middleware"
+	"github.com/cloudretic/matcha/pkg/cors"
+	"github.com/cloudretic/matcha/pkg/middleware"
 )
 
 // RouteConfigFuncs can be applied to a Route at creation.

--- a/pkg/route/default.go
+++ b/pkg/route/default.go
@@ -7,9 +7,9 @@ import (
 	"net/url"
 	"regexp"
 
-	"github.com/cloudretic/router/pkg/middleware"
-	"github.com/cloudretic/router/pkg/path"
-	"github.com/cloudretic/router/pkg/rctx"
+	"github.com/cloudretic/matcha/pkg/middleware"
+	"github.com/cloudretic/matcha/pkg/path"
+	"github.com/cloudretic/matcha/pkg/rctx"
 )
 
 //=====PARTS=====

--- a/pkg/route/default_test.go
+++ b/pkg/route/default_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/cloudretic/router/pkg/rctx"
+	"github.com/cloudretic/matcha/pkg/rctx"
 )
 
 func TestStringPart(t *testing.T) {

--- a/pkg/route/part.go
+++ b/pkg/route/part.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/cloudretic/router/pkg/regex"
+	"github.com/cloudretic/matcha/pkg/regex"
 )
 
 const (

--- a/pkg/route/partial.go
+++ b/pkg/route/partial.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/cloudretic/router/pkg/middleware"
-	"github.com/cloudretic/router/pkg/path"
-	"github.com/cloudretic/router/pkg/rctx"
+	"github.com/cloudretic/matcha/pkg/middleware"
+	"github.com/cloudretic/matcha/pkg/path"
+	"github.com/cloudretic/matcha/pkg/rctx"
 )
 
 // =====PARTS=====

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -3,7 +3,7 @@ package route
 import (
 	"net/http"
 
-	"github.com/cloudretic/router/pkg/middleware"
+	"github.com/cloudretic/matcha/pkg/middleware"
 )
 
 type Route interface {

--- a/pkg/route/route_bench_test.go
+++ b/pkg/route/route_bench_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/cloudretic/router/pkg/rctx"
+	"github.com/cloudretic/matcha/pkg/rctx"
 )
 
 func use(any) {}

--- a/pkg/route/route_test.go
+++ b/pkg/route/route_test.go
@@ -7,8 +7,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/cloudretic/router/pkg/cors"
-	"github.com/cloudretic/router/pkg/rctx"
+	"github.com/cloudretic/matcha/pkg/cors"
+	"github.com/cloudretic/matcha/pkg/rctx"
 )
 
 func invalidConfigFunc(r Route) error {

--- a/pkg/router/config.go
+++ b/pkg/router/config.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/cloudretic/router/pkg/cors"
-	"github.com/cloudretic/router/pkg/middleware"
-	"github.com/cloudretic/router/pkg/route"
+	"github.com/cloudretic/matcha/pkg/cors"
+	"github.com/cloudretic/matcha/pkg/middleware"
+	"github.com/cloudretic/matcha/pkg/route"
 )
 
 // ConfigFuncs run on Routers, usually to add a route or attach middleware.

--- a/pkg/router/default.go
+++ b/pkg/router/default.go
@@ -3,10 +3,10 @@ package router
 import (
 	"net/http"
 
-	"github.com/cloudretic/router/pkg/middleware"
-	"github.com/cloudretic/router/pkg/rctx"
-	"github.com/cloudretic/router/pkg/route"
-	"github.com/cloudretic/router/pkg/tree"
+	"github.com/cloudretic/matcha/pkg/middleware"
+	"github.com/cloudretic/matcha/pkg/rctx"
+	"github.com/cloudretic/matcha/pkg/route"
+	"github.com/cloudretic/matcha/pkg/tree"
 )
 
 type defaultRouter struct {

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -3,8 +3,8 @@ package router
 import (
 	"net/http"
 
-	"github.com/cloudretic/router/pkg/middleware"
-	"github.com/cloudretic/router/pkg/route"
+	"github.com/cloudretic/matcha/pkg/middleware"
+	"github.com/cloudretic/matcha/pkg/route"
 )
 
 type Router interface {

--- a/pkg/router/router_bench_test.go
+++ b/pkg/router/router_bench_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/cloudretic/router/pkg/route"
+	"github.com/cloudretic/matcha/pkg/route"
 )
 
 // mock response writer, taken from go-http-routing-benchmark

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -12,10 +12,10 @@ import (
 
 	"sync"
 
-	"github.com/cloudretic/router/pkg/cors"
+	"github.com/cloudretic/matcha/pkg/cors"
 
-	"github.com/cloudretic/router/pkg/rctx"
-	"github.com/cloudretic/router/pkg/route"
+	"github.com/cloudretic/matcha/pkg/rctx"
+	"github.com/cloudretic/matcha/pkg/route"
 )
 
 // Return a handler that writes OK to all requests

--- a/pkg/tree/tree.go
+++ b/pkg/tree/tree.go
@@ -3,8 +3,8 @@ package tree
 import (
 	"net/http"
 
-	"github.com/cloudretic/router/pkg/path"
-	"github.com/cloudretic/router/pkg/route"
+	"github.com/cloudretic/matcha/pkg/path"
+	"github.com/cloudretic/matcha/pkg/route"
 )
 
 const NO_LEAF_ID = int(0)

--- a/pkg/tree/tree_bench_test.go
+++ b/pkg/tree/tree_bench_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/cloudretic/router/pkg/route"
+	"github.com/cloudretic/matcha/pkg/route"
 )
 
 var routes []string = []string{

--- a/pkg/tree/tree_test.go
+++ b/pkg/tree/tree_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/cloudretic/router/pkg/rctx"
-	"github.com/cloudretic/router/pkg/route"
+	"github.com/cloudretic/matcha/pkg/rctx"
+	"github.com/cloudretic/matcha/pkg/route"
 )
 
 func TestTree(t *testing.T) {


### PR DESCRIPTION
Module name now matches GitHub path.