### PR TITLE
Contribution policy update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.so
 *.dylib
 
+# Test output artifacts; should be local-only
+.cicd/*
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ We welcome community contributions to `matcha`!
 Matcha's latest stable release is `v1.1.0` (major version 1, minor version 1, patch 0). This release, and all future releases, are tagged in the GitHub repository. We follow these guidelines when deciding if a change is major, minor, or patch:
 
 - Major: The change is non-essential and breaks the existing API. See our backwards compatiblility policy [here](docs/versioning.md). Major changes should relate to branch `v1.2.0`.
-- Minor: The change doesn't break the existing API, but changes large portions of the internals of the library, or adds significant functionality to the API. Minor changes should relate to branch `v1.1.1`.
-- Patch: The change is a bugfix, minor performance improvement, minor API change, or auxilary component (like middleware).
+- Minor: The change doesn't break the existing API, but changes large portions of the internals of the library, or adds significant functionality to the API. Minor changes should relate to branch `v1.2.0`.
+- Patch: The change is a bugfix, minor performance improvement, minor API change, or auxilary component (like middleware). Patches should relate to branch `main`.
 
 ## Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,14 @@
 # Contributing to Router
 
-> ***The current development branch is `v1.2`.***
-
 We welcome community contributions to `matcha`!
+
+## Versioning
+
+Matcha's latest stable release is `v1.1.0` (major version 1, minor version 1, patch 0). This release, and all future releases, are tagged in the GitHub repository. We follow these guidelines when deciding if a change is major, minor, or patch:
+
+- Major: The change is non-essential and breaks the existing API. See our backwards compatiblility policy [here](docs/versioning.md). Major changes should relate to branch `v1.2.0`.
+- Minor: The change doesn't break the existing API, but changes large portions of the internals of the library, or adds significant functionality to the API. Minor changes should relate to branch `v1.1.1`.
+- Patch: The change is a bugfix, minor performance improvement, minor API change, or auxilary component (like middleware).
 
 ## Getting Started
 
@@ -13,7 +19,7 @@ We welcome community contributions to `matcha`!
 
 ## Creating a Branch for Changes
 
-1. Identify the version number you would like to make a change to. *The current active development branch is noted at the top of this document.*
+1. Identify the version branch you would like to make a change to. *These branches are specified in Versioning*.
 2. Ensure that your local repository is up to date:
 
     ```bash
@@ -40,7 +46,3 @@ Currently, new submissions to `matcha` are subject to the following criteria:
 2. **Testing**: Test coverage should stay above 95%. New behavior is expected to have associated unit tests
 3. **Documentation**: CloudRETIC strongly encourages detailed documentation of code, and pull requests will be evaluated on quality of comments and external documentation in `/docs`.
 4. **Style**: While style is massively subjective, you should follow good Go code practices. We use [this list](https://github.com/golang/go/wiki/CodeReviewComments#gofmt) to evaluate style.
-
-## Divergent Branches
-
-`main` should not diverge from *future* versions, but may diverge from *past* versions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ Matcha's latest stable release is `v1.1.0` (major version 1, minor version 1, pa
 - Minor: The change doesn't break the existing API, but changes large portions of the internals of the library, or adds significant functionality to the API. Minor changes should relate to branch `v1.2.0`.
 - Patch: The change is a bugfix, minor performance improvement, minor API change, or auxilary component (like middleware). Patches should relate to branch `main`.
 
+Release eligibility will be evaluated bimonthly, with the next evaluation being July 1, 2023.
+
 ## Getting Started
 
 1. Ensure you have [installed Golang](https://go.dev/dl/) on your development machine. `matcha` is currently on version `1.20.2`.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 FORCE:
 
 test:
-	go test -coverprofile cicd/cover.out ./pkg/...
+	go test -coverprofile .cicd/cover.out ./pkg/...
 
 cover: test
-	go tool cover -html cicd/cover.out
+	go tool cover -html .cicd/cover.out
 
 bench: FORCE
 	go test -benchmem -bench=. ./pkg/...

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@
 Supported versions:
 
 - `v1.0`
-- `main (v1.1)`
-- `v1.2`
+- `v1.1.0 (stable release, recommended)`
 
 ## Basic Usage
 
@@ -68,7 +67,7 @@ Long answer: Go benchmarks provide a measurement of `ns/op` and `B/op`, represen
 Router Name | Relative Speed | Memory Use
 --- | --- | ---
 [`gorilla/mux`](https://github.com/gorilla/mux) | .06x | 199,686 B/op
-`matcha` | 1.0x | 139,064 B/op
+`matcha` | 1.0x | 67,928 B/op
 [`chi`](https://github.com/go-chi/chi) | 1.52x | 61,713 B/op
 [`httprouter`](https://github.com/julienschmidt/httprouter) | 5.87x | 13,792 B/op
 [`gin`](https://github.com/gin-gonic/gin) | 5.87x | 0 B/op

--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@
 
 `go get github.com/cloudretic/matcha[@version]`
 
-Supported versions:
+Stable versions:
 
 - `v1.0`
 - `v1.1.0 (stable release, recommended)`
+
+Omitting the version will fetch the main branch, which may contain unreleased but stable features.
 
 ## Basic Usage
 

--- a/pkg/rctx/params.go
+++ b/pkg/rctx/params.go
@@ -32,8 +32,8 @@ func newParams(size int) *routeParams {
 }
 
 func (rps *routeParams) get(key paramKey) string {
-	for i := rps.head; i > 0; i-- {
-		kv := rps.rps[i-1]
+	for i := 0; i < rps.head; i++ {
+		kv := rps.rps[i]
 		if kv.key == key {
 			return kv.value
 		}
@@ -42,11 +42,22 @@ func (rps *routeParams) get(key paramKey) string {
 }
 
 func (rps *routeParams) set(key paramKey, value string) error {
-	if rps.head >= rps.cap {
-		return errors.New("placeholder error; over capacity")
+	idx := rps.head
+	inc := true
+	for i := 0; i < rps.head; i++ {
+		kv := rps.rps[i]
+		if kv.key == key {
+			idx = i
+			inc = false
+		}
 	}
-	rps.rps[rps.head].key = key
-	rps.rps[rps.head].value = value
-	rps.head++
+	if idx >= rps.cap {
+		return errors.New("over capacity")
+	}
+	if inc {
+		rps.head++
+	}
+	rps.rps[idx].key = key
+	rps.rps[idx].value = value
 	return nil
 }

--- a/pkg/rctx/rctx_test.go
+++ b/pkg/rctx/rctx_test.go
@@ -53,6 +53,10 @@ func TestNative(t *testing.T) {
 				t.Errorf("expected %s, got %s", v, got)
 			}
 		}
+		SetParam(ctx, "p0", "diffValue")
+		if v := GetParam(ctx, "p0"); v != "diffValue" {
+			t.Errorf("expected diffValue, got %s", v)
+		}
 		ResetRequestContext(req)
 		got := GetParam(ctx, "p0")
 		if got != "" {

--- a/pkg/route/util.go
+++ b/pkg/route/util.go
@@ -1,0 +1,13 @@
+package route
+
+// Get the number of params that need to be allocated for this route.
+func NumParams(r Route) int {
+	ct := 0
+	ps := r.Parts()
+	for _, p := range ps {
+		if pp, ok := p.(paramPart); ok && pp.ParameterName() != "" {
+			ct++
+		}
+	}
+	return ct
+}

--- a/pkg/route/util_test.go
+++ b/pkg/route/util_test.go
@@ -1,0 +1,25 @@
+package route
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestNumParams(t *testing.T) {
+	r1 := Declare(http.MethodGet, "/static/route")
+	if np := NumParams(r1); np != 0 {
+		t.Errorf("expected 0 params, got %d", np)
+	}
+	r2 := Declare(http.MethodGet, "/[wc1]{.+}/[wc2]")
+	if np := NumParams(r2); np != 2 {
+		t.Errorf("expected 2 params, got %d", np)
+	}
+	r3 := Declare(http.MethodGet, "/[wc1]{.+}/[wc2]/[wc3]+")
+	if np := NumParams(r3); np != 3 {
+		t.Errorf("expected 3 params, got %d", np)
+	}
+	r4 := Declare(http.MethodGet, "/{.+}/[wc2]/+")
+	if np := NumParams(r4); np != 1 {
+		t.Errorf("expected 1 params, got %d", np)
+	}
+}


### PR DESCRIPTION
Working on updating contribution/versioning policies to be more in line with Go's packaging system. This commit will represent release 1.1.0.

Also, made rctx stop allocating so much memory it doesn't need. Since it's no longer required to allocate the max potential space and reset each route, it now matches via tree, gets the number of parameters required, and then stores params. Cut memory use by a good bit.