### PR TITLE
Conditionally improve performance by pooling context

### DIFF
--- a/pkg/rctx/rctx.go
+++ b/pkg/rctx/rctx.go
@@ -30,6 +30,7 @@ func new(parent context.Context, maxParams int) *Context {
 	if rctx.params == nil || rctx.params.cap < maxParams {
 		rctx.params = newParams(maxParams)
 	} else {
+		rctx.params.cap = maxParams
 		rctx.params.head = 0
 	}
 	return rctx
@@ -55,6 +56,8 @@ func ResetRequestContext(req *http.Request) error {
 
 func ReturnRequestContext(req *http.Request) {
 	if rctx, ok := req.Context().(*Context); ok {
+		rctx.parent = nil
+		rctx.err = nil
 		for i := range rctx.params.rps {
 			rctx.params.rps[i].key = ""
 			rctx.params.rps[i].value = ""

--- a/pkg/rctx/rctx.go
+++ b/pkg/rctx/rctx.go
@@ -55,6 +55,10 @@ func ResetRequestContext(req *http.Request) error {
 
 func ReturnRequestContext(req *http.Request) {
 	if rctx, ok := req.Context().(*Context); ok {
+		for i := range rctx.params.rps {
+			rctx.params.rps[i].key = ""
+			rctx.params.rps[i].value = ""
+		}
 		rctxPool.Put(rctx)
 	}
 }

--- a/pkg/rctx/rctx.go
+++ b/pkg/rctx/rctx.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync"
 	"time"
 )
 
@@ -17,13 +18,26 @@ type Context struct {
 	err    error
 }
 
+var rctxPool = &sync.Pool{
+	New: func() any {
+		return &Context{}
+	},
+}
+
+func new(parent context.Context, maxParams int) *Context {
+	rctx := rctxPool.Get().(*Context)
+	rctx.parent = parent
+	if rctx.params == nil || rctx.params.cap < maxParams {
+		rctx.params = newParams(maxParams)
+	} else {
+		rctx.params.head = 0
+	}
+	return rctx
+}
+
 // PrepareRequestContext prepares the context of a request for matching.
 func PrepareRequestContext(req *http.Request, maxParams int) *http.Request {
-	rctx := &Context{
-		parent: req.Context(),
-		params: newParams(maxParams),
-		err:    nil,
-	}
+	rctx := new(req.Context(), maxParams)
 	return req.WithContext(rctx)
 }
 
@@ -37,6 +51,12 @@ func ResetRequestContext(req *http.Request) error {
 	}
 	rctx.params.head = 0
 	return nil
+}
+
+func ReturnRequestContext(req *http.Request) {
+	if rctx, ok := req.Context().(*Context); ok {
+		rctxPool.Put(rctx)
+	}
 }
 
 // PARAMETER IMPLEMENTATION

--- a/pkg/router/default.go
+++ b/pkg/router/default.go
@@ -69,6 +69,7 @@ func (rt *defaultRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 		rt.handlers[req.Method][leaf_id].ServeHTTP(w, reqWithCtx)
+		rctx.ReturnRequestContext(req)
 		return
 	}
 	rt.notfound.ServeHTTP(w, req)

--- a/pkg/router/default.go
+++ b/pkg/router/default.go
@@ -66,6 +66,7 @@ func (rt *defaultRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		reqWithCtx := r.MatchAndUpdateContext(req)
 		reqWithCtx = executeMiddleware(r.Middleware(), w, reqWithCtx)
 		if reqWithCtx == nil {
+			rctx.ReturnRequestContext(req)
 			return
 		}
 		rt.handlers[req.Method][leaf_id].ServeHTTP(w, reqWithCtx)


### PR DESCRIPTION
Internally, package `rctx` now pulls from a `*sync.Pool` when preparing requests, with the default router explicitly returning those contexts to the pool once a request is matched and handled.

This is primarily a performance improvement for routers that are persistent and have consistent traffic, as one request must conclude and return its context to the pool for it to be picked up by a subsequent request, and the router must be continuously running in order to maintain the pool. This PR does not reduce performance for use cases outside of this one.