### PR TITLE
V1.2.0 merge up

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Matcha's latest stable release is `v1.1.0` (major version 1, minor version 1, pa
 - Minor: The change doesn't break the existing API, but changes large portions of the internals of the library, or adds significant functionality to the API. Minor changes should relate to branch `v1.2.0`.
 - Patch: The change is a bugfix, minor performance improvement, minor API change, or auxilary component (like middleware). Patches should relate to branch `main`.
 
-Release eligibility will be evaluated bimonthly, with the next evaluation being July 1, 2023.
+Release eligibility will be evaluated monthly, with the next evaluation being on May 1, 2023.
 
 ## Getting Started
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,21 @@
 # Contributing to Router
 
-We welcome community contributions to `matcha`!
+We welcome community contributions to Matcha!
 
 ## Versioning
 
-Matcha's latest stable release is `v1.1.0` (major version 1, minor version 1, patch 0). This release, and all future releases, are tagged in the GitHub repository. We follow these guidelines when deciding if a change is major, minor, or patch:
+Matcha's latest stable release is `v1.1.0` (major version 1, minor version 1, patch 0). Releases are tagged in the GitHub repository. We follow these guidelines when deciding if a change is major, minor, or patch:
 
-- Major: The change is non-essential and breaks the existing API. See our backwards compatiblility policy [here](docs/versioning.md). Major changes should relate to branch `v1.2.0`.
+- Major: The change is non-essential and breaks the existing API. See our backwards compatiblility policy [here](docs/versioning.md). Major changes are not currently being accepted.
 - Minor: The change doesn't break the existing API, but changes large portions of the internals of the library, or adds significant functionality to the API. Minor changes should relate to branch `v1.2.0`.
 - Patch: The change is a bugfix, minor performance improvement, minor API change, or auxilary component (like middleware). Patches should relate to branch `main`.
 
-Release eligibility will be evaluated monthly, with the next evaluation being on May 1, 2023.
+Release eligibility will be evaluated biweekly, with the next evaluation being on May 15, 2023.
 
 ## Getting Started
 
-1. Ensure you have [installed Golang](https://go.dev/dl/) on your development machine. `matcha` is currently on version `1.20.2`.
-2. Create a fork of `matcha` to your personal GitHub account. Direct branches or pushes to the `CloudRETIC` repository are not accepted.
+1. Ensure you have [installed Golang](https://go.dev/dl/) on your development machine. Matcha is currently on version `1.20.2`.
+2. Create a fork of Matcha to your personal GitHub account. Direct branches or pushes to the `CloudRETIC` repository are not accepted.
 3. Clone your personal fork to your development machine, and enter the directory.
 4. Add the upstream repository: `git remote add upstream [http-or-ssh-address]`
 
@@ -42,7 +42,7 @@ Once your changes are approved, they'll be squash-and-merged into the feature br
 
 ## Guidelines
 
-Currently, new submissions to `matcha` are subject to the following criteria:
+Currently, new submissions to Matcha are subject to the following criteria:
 
 1. **Performance**: Changes must not significantly decrease performance unless they are urgent bugfixes. Benchmarks for routers and routes, as well as a more comprehensive benchmark on the GitHub API (courtesy of [julienschmidt](https://github.com/julienschmidt/go-http-routing-benchmark)) are provided to help evaluate this as you work. Run benchmarks before and after making changes to most accurately assess impact.
 2. **Testing**: Test coverage should stay above 95%. New behavior is expected to have associated unit tests

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # matcha
 
-[![Coverage Status](https://coveralls.io/repos/github/cloudretic/router/badge.svg)](https://coveralls.io/github/cloudretic/router)
+[![Coverage Status](https://coveralls.io/repos/github/cloudretic/matcha/badge.svg)](https://coveralls.io/github/cloudretic/router)
+[![Discord Badge](https://img.shields.io/badge/Join%20us%20on-Discord-blue)](https://discord.gg/gCdJ6NPm)
 
 `cloudretic/matcha` is an actively developed HTTP router for Go, primarily developed for CloudRETIC's API handlers but free to use by anyone under the Apache 2.0 license.
-
-> **In version 1.1, `cloudretic/router` will be renamed to `cloudretic/matcha`.** The former name is too generic to support long-term. We apologize for any inconvenience caused by this change.
 
 ## Features
 
@@ -13,6 +12,8 @@
 - Comprehensive and passing test coverage, and extensive benchmarks to track performance
 - Native middleware to help you add common functionality, extensible when native support doesn't fit your use case
 - No dependencies, what you see is what you get
+
+For a preview of what's upcoming, see our [roadmap](docs/roadmap.md).
 
 ## Installation
 
@@ -62,17 +63,17 @@ See `docs/` for information on implementing more advanced features.
 
 > These benchmarks are run on the GitHub API provided by [julienschmidt](https://github.com/julienschmidt/go-http-routing-benchmark), updated to match the current Go version.
 
-Short answer: in tests with handling of *single requests* to a large API (~200 routes), `matcha` can handle requests end-to-end in about 470 nanoseconds, using about 720 bytes of memory, when running on an M2 MacBook Pro.
+Short answer: in tests with handling of *single requests* to a large API (~200 routes), Matcha can handle requests end-to-end in about 470 nanoseconds, using about 720 bytes of memory, when running on an M2 MacBook Pro.
 
-Long answer: Go benchmarks provide a measurement of `ns/op` and `B/op`, representing how much time and memory was used for one "operation", which in this case is one full loop of handling *every route* in the API, a common metric used to compare http routers in Go. Since speed in nanoseconds can be machine-dependent, we have provided a relative value instead for this comparison, where the value is (`matcha` result)/(`other` result). Higher is better/faster.
+Long answer: Go benchmarks provide a measurement of `ns/op` and `B/op`, representing how much time and memory was used for one "operation", which in this case is one full loop of handling *every route* in the API, a common metric used to compare http routers in Go. Since speed in nanoseconds can be machine-dependent, we have provided a relative value instead for this comparison, where the value is (Matcha result)/(`other` result). Higher is better/faster.
 
 Router Name | Relative Speed | Memory Use
 --- | --- | ---
 [`gorilla/mux`](https://github.com/gorilla/mux) | .06x | 199,686 B/op
-`matcha` | 1.0x | 67,928 B/op
-[`chi`](https://github.com/go-chi/chi) | 1.52x | 61,713 B/op
-[`httprouter`](https://github.com/julienschmidt/httprouter) | 5.87x | 13,792 B/op
-[`gin`](https://github.com/gin-gonic/gin) | 5.87x | 0 B/op
+`cloudretic/matcha` | 1.0x | 67,928 B/op
+[`go-chi/chi`](https://github.com/go-chi/chi) | 1.52x | 61,713 B/op
+[`julienschmidt/httprouter`](https://github.com/julienschmidt/httprouter) | 5.87x | 13,792 B/op
+[`gin-gonic/gin`](https://github.com/gin-gonic/gin) | 5.87x | 0 B/op
 
 ## Maintainers
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -1,0 +1,22 @@
+# Context in Matcha
+
+In keeping with the "stay fully compatible with the standard library" design goal, Matcha has a custom implementation of `context.Context`. While it is possible to interact with this library entirely the same way as one would with standard context, package `rctx` defines some additional ways to use it, primarily through getting and setting parameters.
+
+## Attaching Context to a Route
+
+`rctx.PrepareRequestContext` takes in an `http.Request` and a number of parameters to allocate, and returns a request with its context modified in the following ways:
+
+- The old request context becomes the *parent* of the new one.
+- The new context has space for `maxParams` params.
+
+## Get/Set Params
+
+`rctx.GetParam` and `rctx.SetParam` are used to manage route parameters (the parts in square brackets), and interact with `*rctx.Context` to store these values. The most common use case for this is just to call `GetParam` with a request context to get a named route parameter.
+
+```go
+func HandleReq(w *http.ResponseWriter, req *http.Request) {
+    id := rctx.GetParam(req.Context(), "id")
+}
+```
+
+This works even if the context has been updated in middleware; `GetParam` is type-agnostic, and as long as the original request context is used in the new one, the call will be passed down until the parameter is found or the context chain is exhausted. However, `SetParam` *requires* that the provided context be of type `*rctx.Context` as a safety feature to keep memory use low. As a result, it's recommended that you use `context.WithValue` (or other functions) in middleware instead.

--- a/docs/design.md
+++ b/docs/design.md
@@ -13,4 +13,4 @@ Generally, it is encouraged that you pick one and stick to it for both routes an
 
 ## Handlers
 
-Some routers use specialized handler functions or types in their APIs. While separating from Go's standard HTTP library can lead to performance improvements, it also leads to stronger coupling with the package being used. We've re-implemented some of the interface members of the HTTP library, allowing for high performance without the need for refactoring code to migrate to `matcha`. Any handler that works with Go's standard library works for `matcha` as well.
+Some routers use specialized handler functions or types in their APIs. While separating from Go's standard HTTP library can lead to performance improvements, it also leads to stronger coupling with the package being used. We've re-implemented some of the interface members of the HTTP library, allowing for high performance without the need for refactoring code to migrate to Matcha. Any handler that works with Go's standard library works for Matcha as well.

--- a/docs/other-features.md
+++ b/docs/other-features.md
@@ -12,7 +12,7 @@
 
 ## Cross-Origin Resource Sharing (CORS)
 
-When requesting resources from a remote server, browsers typically require the server to describe the conditions under which a request may access those resources. This is called Cross-Origin Resource Sharing. `matcha` has some tools built in to help you handle CORS requests, if it's required for your application.
+When requesting resources from a remote server, browsers typically require the server to describe the conditions under which a request may access those resources. This is called Cross-Origin Resource Sharing. Matcha has some tools built in to help you handle CORS requests, if it's required for your application.
 
 ### How CORS Works
 
@@ -30,7 +30,7 @@ If the request is simple, it's sent as normal. If it is not simple, the browser 
 - `Access-Control-Max-Age`: Indicates how long a resource may be cached in seconds.
 - `Access-Control-Allow-Credentials`: Indicates if a request may use credentials (cookies, authorization, or TLS).
 
-All of these can be empty, a list, or `*`, which indicates that any value is allowed/exposed. `matcha` represents these with the `*AccessControlOptions` struct, used to define how a Router should treat CORS requests.
+All of these can be empty, a list, or `*`, which indicates that any value is allowed/exposed. Matcha represents these with the `*AccessControlOptions` struct, used to define how a Router should treat CORS requests.
 
 ### Setting Up CORS
 
@@ -38,7 +38,7 @@ There are three ways to set CORS headers on responses.
 
 - `Router` can set the default headers for all routes using the `DefaultCORSHeaders` configuration function.
 - `Route` can set the headers for itself only using the `CORSHeaders` configuration function.
-- `PreflightCORS` can be used to define an OPTIONS route that returns the given access control headers. *`matcha` does not currently automatically generate these routes.*
+- `PreflightCORS` can be used to define an OPTIONS route that returns the given access control headers. *Matcha does not currently automatically generate these routes.*
 
 To manually manipulate CORS headers, `package cors` provides `SetCORSResponseHeaders` that will set the headers based on an `*AccessControlOptions` object. This can be used in the event that the above options don't fit your use case. We'd encourage you to submit an issue on GitHub if your use case isn't immediately supported.
 
@@ -66,11 +66,11 @@ r := Declare(
 
 ## Logging
 
-`matcha` provides middleware options for logging inbound requests. Each option takes in an `io.Writer`, and writes logs in a specified format for each request. `middleware.LogRequests` and `middleware.LogRequestsIf` will write in the format `[timestamp] [origin] [method] [url]`. Timestamps are in UNIX with nanosecond precision, and the origin will be `-` if it is empty in the request.
+Matcha provides middleware options for logging inbound requests. Each option takes in an `io.Writer`, and writes logs in a specified format for each request. `middleware.LogRequests` and `middleware.LogRequestsIf` will write in the format `[timestamp] [origin] [method] [url]`. Timestamps are in UNIX with nanosecond precision, and the origin will be `-` if it is empty in the request.
 
 ## Adapters
 
-`matcha` includes the `Adapter` interface to help define functionality that receives HTTP requests through methods other than direct HTTP/S, such as with serverless computing or through a message queue. External adapters aren't required to use this, but it may help.
+Matcha includes the `Adapter` interface to help define functionality that receives HTTP requests through methods other than direct HTTP/S, such as with serverless computing or through a message queue. External adapters aren't required to use this, but it may help.
 
 ### Implementing the Adapter Interface
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,9 +1,18 @@
 # Roadmap
 
-What's next for `matcha`?
+Matcha is actively maintained, and we're always looking for feature requests, bug reports, and general improvements. Below is what we have planned for the near future. Please keep in mind that this is not an exhaustive list!
 
-## Version 1.2: Use Case Support
+## Version 1.1.1
 
-- Reverse Proxy
-- File Server
-- Serverless HTTP Adapters (AWS Lambda, etc)
+Planned for release by May 15, 2023
+
+- Adapter for middleware of the form `http.Handler`
+- Specified behavior for duplicate routes in preparation for 1.2.0 route validation
+- Performance improvements
+
+## Version 1.2.0
+
+Planned for release by July 1, 2023
+
+- Additional route validation: match against host, origin, etc.
+- Error handling: shorthand access to a generic error response and the [RFC 7801](https://datatracker.ietf.org/doc/draft-ietf-httpapi-rfc7807bis/) problem+json proposal

--- a/docs/routers.md
+++ b/docs/routers.md
@@ -12,7 +12,7 @@ r := router.Declare(
 r.AddRoute(route.Declare(http.MethodGet, "/someOtherEndpoint"), someOtherHandler)
 ```
 
-Routes will be handled in the order they are added.
+Routes will be handled in the order they are added. Re-adding a route with the same method and path does not change the handler or middleware for that route; only the first instance of a duplicate route will be matched against.
 
 You can also add a specific handler that's called in the event that no route matches using `WithNotFound` or `AddNotFound` in the same way (the router will return an empty 404 by default). Doing so will override any previously-set handler for this case.
 

--- a/docs/routers.md
+++ b/docs/routers.md
@@ -45,7 +45,7 @@ router.Attach(someOtherMiddleware)
 
 ## Matching
 
-As of version 1.1, `matcha` uses a tree-based system to match requests. When adding routes, the `Part`s of the route are added to a tree, where equivalent `Part`s are combined into the same node. Requested routes are compared to this tree using a depth-first traversal, in the same order that the routes were added. For example, take this tree for the following set of routes. Note that leaf nodes are not overwritten by routes that extend beyond them.
+As of version 1.1, Matcha uses a tree-based system to match requests. When adding routes, the `Part`s of the route are added to a tree, where equivalent `Part`s are combined into the same node. Requested routes are compared to this tree using a depth-first traversal, in the same order that the routes were added. For example, take this tree for the following set of routes. Note that leaf nodes are not overwritten by routes that extend beyond them.
 
 ```txt
 1: /static
@@ -59,4 +59,4 @@ root -- static
                 \ other -- route
 ```
 
-Some routers support exact routes only, as defining behavior for conflicting routes can be expensive. `matcha` supports wildcards, regex validation, and partial routes, all of which can lead to conflicts. To avoid incurring performance costs, `matcha` currently supports only *first match*, which means that the first "correct" route, in order of their registration, will be matched, regardless of if there is another conflicting one registered after.
+Some routers support exact routes only, as defining behavior for conflicting routes can be expensive. Matcha supports wildcards, regex validation, and partial routes, all of which can lead to conflicts. To avoid incurring performance costs, Matcha currently supports only *first match*, which means that the first "correct" route, in order of their registration, will be matched, regardless of if there is another conflicting one registered after.

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -8,7 +8,7 @@ Routes are defined using *expressions* and made up of *parts*. When creating a r
 
 ## Route Parts
 
- `matcha` has support for special syntax to customize the behavior of "parts". Currently, it supports:
+ Matcha has support for special syntax to customize the behavior of "parts". Currently, it supports:
 
 - Static strings
 - Wildcard parameters

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,10 +1,10 @@
 # Matcha and Version Control
 
-One of the priorities of `matcha` is *backwards compatibility*; that is, updates to the minor version of the library shouldn't break pre-existing codebases using it. To clarify what that means for developers, this document lays out how backwards compatibility is maintained, and under what circumstances that policy might be violated, and what happens when those circumstances occur.
+One of the priorities of Matcha is *backwards compatibility*; that is, updates to the minor version of the library shouldn't break pre-existing codebases using it. To clarify what that means for developers, this document lays out how backwards compatibility is maintained, and under what circumstances that policy might be violated, and what happens when those circumstances occur.
 
 ## Maintaining Backwards Compatibility
 
-Most of `matcha`'s developer-facing capabilities are behind interfaces, collections of types that can do a certain set of clearly-defined things. Some are defined by us, while some are defined by the Go standard library, like `context.Context`. What this means in practice is that when changes are made to the underlying mechanisms of routers, routes, and context, the code that you use to invoke those things doesn't change. The result is an easy-to-read definition of what functionality will always be available to you, the developer, throughout versions.
+Most of Matcha's developer-facing capabilities are behind interfaces, collections of types that can do a certain set of clearly-defined things. Some are defined by us, while some are defined by the Go standard library, like `context.Context`. What this means in practice is that when changes are made to the underlying mechanisms of routers, routes, and context, the code that you use to invoke those things doesn't change. The result is an easy-to-read definition of what functionality will always be available to you, the developer, throughout versions.
 
 Any changes to public/exported packages will not remove features until version 2.0, even if that functionality ceases use internally.
 

--- a/pkg/adapter/adapter.go
+++ b/pkg/adapter/adapter.go
@@ -1,3 +1,7 @@
+// Package adapter implements an optional interface for use with non-standard requests.
+//
+// Use of this package is optional when writing adapters for other services, but serves as
+// a good representation of what may be needed.
 package adapter
 
 import "net/http"

--- a/pkg/cors/cors.go
+++ b/pkg/cors/cors.go
@@ -1,3 +1,6 @@
+// Package cors defines a set of useful handlers and middleware for setting access control values.
+//
+// See [https://github.com/cloudretic/matcha/blob/main/docs/other-features.md#cross-origin-resource-sharing-cors].
 package cors
 
 import (
@@ -49,8 +52,11 @@ type AccessControlOptions struct {
 }
 
 // Create a deep copy of aco that reflects the headers in crh.
+// Reflection means that for each option in aco, the resulting aco will contain any values in crh that match it;
+// as a result, the output has the minimum number of permissions needed to fulfill the provided headers. This should
+// not be used as a security feature.
 // If there is no option in aco that can reflect crh, the output will have an empty field; this is intended behavior
-// and indicates to the HTTP client that resource sharing should not be allowed for this request
+// and indicates to the HTTP client that resource sharing should not be allowed for this request.
 func ReflectCORSRequestHeaders(aco *AccessControlOptions, crh *CORSRequestHeaders) *AccessControlOptions {
 	out := &AccessControlOptions{
 		AllowOrigin:      make([]string, 1),
@@ -105,6 +111,8 @@ func ReflectCORSRequestHeaders(aco *AccessControlOptions, crh *CORSRequestHeader
 	return out
 }
 
+// Updates the response headers from http.ResponseWriter to mirror a set of access control options.
+// Mirroring provides the minimum amount of permissions needed for the inbound request via ReflectCorsRequestHeaders.
 func SetCORSResponseHeaders(w http.ResponseWriter, req *http.Request, aco *AccessControlOptions) {
 	crh := GetCORSRequestHeaders(req)
 	res := ReflectCORSRequestHeaders(aco, crh)

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -1,3 +1,6 @@
+// Package middleware defines the middleware format for Matcha.
+//
+// See [https://github.com/cloudretic/matcha/blob/main/docs/routers.md#middleware].
 package middleware
 
 import (

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -114,3 +114,15 @@ type LogEntry struct {
 	Method string
 	URL    *url.URL
 }
+
+// ExecuteMiddleware executes the given middleware functions on the given request.
+// It returns the modified request or nil if any middleware function returns nil.
+func ExecuteMiddleware(mw []Middleware, w http.ResponseWriter, req *http.Request) *http.Request {
+	for _, m := range mw {
+		req = m(w, req)
+		if req == nil {
+			break
+		}
+	}
+	return req
+}

--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -1,5 +1,4 @@
-// package path manages the tokenization of http paths
-// TODO: this should belong to the data repo
+// Package path manages the tokenization of http paths.
 package path
 
 import (
@@ -7,7 +6,7 @@ import (
 )
 
 // Return the next token from a path, starting at position last, and the position to use with the next call.
-// Returns "" if no token could be found
+// Next considers multiple consecutive slashes to act as a single slash.
 func Next(path string, last int) (string, int) {
 	if last+1 > len(path) {
 		return "", -1

--- a/pkg/rctx/rctx.go
+++ b/pkg/rctx/rctx.go
@@ -1,3 +1,6 @@
+// Package rctx defines the context structure for Matcha.
+//
+// See [https://github.com/cloudretic/matcha/blob/main/docs/context.md].
 package rctx
 
 import (

--- a/pkg/regex/regex.go
+++ b/pkg/regex/regex.go
@@ -1,4 +1,4 @@
-// package regex wraps the Golang regexp package
+// Package regex wraps the Golang regexp package to provide more convenient access to some features.
 package regex
 
 import (

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -1,3 +1,6 @@
+// Package route defines the API for creating and interacting with a route, and its internal behavior.
+//
+// See [https://github.com/cloudretic/matcha/blob/main/docs/routes.md].
 package route
 
 import (

--- a/pkg/router/default.go
+++ b/pkg/router/default.go
@@ -29,10 +29,16 @@ func Default() *defaultRouter {
 	}
 }
 
+// Attach middleware to the router.
+//
+// See interface Router.
 func (rt *defaultRouter) Attach(mw middleware.Middleware) {
 	rt.mws = append(rt.mws, mw)
 }
 
+// Add a route to the router.
+//
+// See interface Router.
 func (rt *defaultRouter) AddRoute(r route.Route, h http.Handler) {
 	id := rt.rtree.Add(r)
 	if rt.routes[r.Method()] == nil {
@@ -45,6 +51,9 @@ func (rt *defaultRouter) AddRoute(r route.Route, h http.Handler) {
 	rt.handlers[r.Method()][id] = h
 }
 
+// Set the handler for instances where no route is found.
+//
+// See interface Router.
 func (rt *defaultRouter) AddNotFound(h http.Handler) {
 	rt.notfound = h
 }

--- a/pkg/router/default.go
+++ b/pkg/router/default.go
@@ -55,7 +55,7 @@ func (rt *defaultRouter) AddNotFound(h http.Handler) {
 // Tree Router organizes routes by their 'prefixes' (first path elements) and serves based on the first
 // path element of the request. Since wildcard and regex parts do not statically evaluate, they are stored as "*".
 func (rt *defaultRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	req = executeMiddleware(rt.mws, w, req)
+	req = middleware.ExecuteMiddleware(rt.mws, w, req)
 	if req == nil {
 		return
 	}
@@ -64,7 +64,7 @@ func (rt *defaultRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		r := rt.routes[req.Method][leaf_id]
 		req = rctx.PrepareRequestContext(req, route.NumParams(r))
 		reqWithCtx := r.MatchAndUpdateContext(req)
-		reqWithCtx = executeMiddleware(r.Middleware(), w, reqWithCtx)
+		reqWithCtx = middleware.ExecuteMiddleware(r.Middleware(), w, reqWithCtx)
 		if reqWithCtx == nil {
 			return
 		}
@@ -73,13 +73,4 @@ func (rt *defaultRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	rt.notfound.ServeHTTP(w, req)
 	return
-}
-
-func executeMiddleware(mw []middleware.Middleware, w http.ResponseWriter, req *http.Request) *http.Request {
-	for _, m := range mw {
-		if req = m(w, req); req == nil {
-			return nil
-		}
-	}
-	return req
 }

--- a/pkg/router/default.go
+++ b/pkg/router/default.go
@@ -66,9 +66,11 @@ func (rt *defaultRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		reqWithCtx := r.MatchAndUpdateContext(req)
 		reqWithCtx = middleware.ExecuteMiddleware(r.Middleware(), w, reqWithCtx)
 		if reqWithCtx == nil {
+			rctx.ReturnRequestContext(req)
 			return
 		}
 		rt.handlers[req.Method][leaf_id].ServeHTTP(w, reqWithCtx)
+		rctx.ReturnRequestContext(req)
 		return
 	}
 	rt.notfound.ServeHTTP(w, req)

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -1,3 +1,6 @@
+// Package router defines the API for creating and interacting with a router, and its internal behavior.
+//
+// See [https://github.com/cloudretic/matcha/blob/main/docs/routers.md].
 package router
 
 import (

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -328,3 +328,23 @@ func TestCORS(t *testing.T) {
 		t.Error("expected invalid route to fail with preflightcors")
 	}
 }
+
+func TestDuplicate(t *testing.T) {
+	h1 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	h2 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	})
+	r := Declare(
+		Default(),
+		WithRoute(route.Declare(http.MethodGet, "/duplicate/route"), h1),
+		WithRoute(route.Declare(http.MethodGet, "/duplicate/route"), h2),
+	)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/duplicate/route", nil)
+	r.ServeHTTP(w, req)
+	if w.Result().StatusCode != http.StatusOK {
+		t.Errorf("re-declaration should be noop; expected %d, got %d", http.StatusOK, w.Result().StatusCode)
+	}
+}

--- a/pkg/tree/tree.go
+++ b/pkg/tree/tree.go
@@ -1,3 +1,6 @@
+// Package tree defines a method of recursively matching route paths by part.
+//
+// See [https://github.com/cloudretic/matcha/blob/main/docs/routers.md#matching].
 package tree
 
 import (
@@ -91,6 +94,7 @@ type RouteTree struct {
 	nextId     int
 }
 
+// Create a new RouteTree.
 func New() *RouteTree {
 	return &RouteTree{
 		methodRoot: make(map[string]*node),

--- a/pkg/tree/tree_test.go
+++ b/pkg/tree/tree_test.go
@@ -2,6 +2,7 @@ package tree
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/cloudretic/matcha/pkg/rctx"
@@ -43,5 +44,21 @@ func TestTree(t *testing.T) {
 	req = rctx.PrepareRequestContext(req, rctx.DefaultMaxParams)
 	if leaf_id := rtree.Match(req); leaf_id != NO_LEAF_ID {
 		t.Error("route shouldn't exist")
+	}
+}
+
+func TestDuplicate(t *testing.T) {
+	rtree := New()
+	a := rtree.Add(route.Declare(http.MethodGet, "/duplicate/route"))
+	b := rtree.Add(route.Declare(http.MethodGet, "/duplicate/route"))
+	if a != 1 {
+		t.Errorf("expected leaf_id 1, got %d", a)
+	}
+	if b != 2 {
+		t.Errorf("expected leaf_id 2, got %d", b)
+	}
+	c := rtree.Match(httptest.NewRequest(http.MethodGet, "/duplicate/route", nil))
+	if c != 1 {
+		t.Errorf("expected leaf_id 1, got %d", c)
 	}
 }


### PR DESCRIPTION
Bring current patch changes into v1.2.0. Want to do this roughly every eval (biweekly) so we don't end up with more silly merge histories like what happened with v1.1.0.