### PR TITLE
Add Go Report Card and fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Coverage Status](https://coveralls.io/repos/github/cloudretic/matcha/badge.svg)](https://coveralls.io/github/cloudretic/router)
 [![Discord Badge](https://img.shields.io/badge/Join%20us%20on-Discord-blue)](https://discord.gg/gCdJ6NPm)
+[![Go Report Card](https://goreportcard.com/badge/github.com/cloudretic/matcha)](https://goreportcard.com/report/github.com/cloudretic/matcha)
 
 `cloudretic/matcha` is an actively developed HTTP router for Go, primarily developed for CloudRETIC's API handlers but free to use by anyone under the Apache 2.0 license.
 

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -320,11 +320,7 @@ func TestCORS(t *testing.T) {
 	})
 
 	// Test invalid route for preflight
-	r, err := New(
-		Default(),
-		PreflightCORS("/{(}", aco),
-	)
-	if err == nil {
+	if _, err := New(Default(), PreflightCORS("/{(}", aco)); err == nil {
 		t.Error("expected invalid route to fail with preflightcors")
 	}
 }

--- a/pkg/tree/tree.go
+++ b/pkg/tree/tree.go
@@ -29,9 +29,9 @@ func createNode(p route.Part) *node {
 	}
 }
 
-// Propogate a set of parts through the tree, with this node as the root.
-// If there are no parts left to propogate, the node will instead be set to leaf leaf_id.
-func (n *node) propogate(ps []route.Part, leaf_id int) {
+// Propagate a set of parts through the tree, with this node as the root.
+// If there are no parts left to propagate, the node will instead be set to leaf leaf_id.
+func (n *node) propagate(ps []route.Part, leaf_id int) {
 	if len(ps) == 0 {
 		n.leaf_id = leaf_id
 		return
@@ -40,13 +40,13 @@ func (n *node) propogate(ps []route.Part, leaf_id int) {
 	if !n.isLeaf() && len(ps)-1 != 0 {
 		for _, child := range n.children {
 			if child.p.Eq(next) {
-				child.propogate(ps[1:], leaf_id)
+				child.propagate(ps[1:], leaf_id)
 				return
 			}
 		}
 	}
 	child := createNode(next)
-	child.propogate(ps[1:], leaf_id)
+	child.propagate(ps[1:], leaf_id)
 	n.children = append(n.children, child)
 }
 
@@ -111,7 +111,7 @@ func (rtree *RouteTree) Add(r route.Route) int {
 		rtree.methodRoot[r.Method()] = root
 	}
 	rtree.nextId++
-	root.propogate(r.Parts(), rtree.nextId)
+	root.propagate(r.Parts(), rtree.nextId)
 	return rtree.nextId
 }
 


### PR DESCRIPTION
PR for #65 

Go Report also has reported 2 inefficient assigns, but I didn't want to include this to the PR by default, so we can discuss that.
First ineffassign is: (Line 20)
https://github.com/cloudretic/matcha/blob/f535ca497550ca346c1865cb2146e865f3d7d4d5/pkg/rctx/rctx_bench_test.go#L17-L25

What about this? It shouldn't affect the benchmark, but I'm not really familiar with the codebase, so I could be missing something here.
```go
func BenchmarkPrepare(b *testing.B) {
	for i := 0; i < b.N; i++ {
		PrepareRequestContext(&http.Request{}, DefaultMaxParams)
	}
}
```

Second ineffassign is: (Line 323)
https://github.com/cloudretic/matcha/blob/f535ca497550ca346c1865cb2146e865f3d7d4d5/pkg/router/router_test.go#L323-L329

To this:
```go
if _, err := New(Default(), PreflightCORS("/{(}", aco)); err == nil {
	t.Error("expected invalid route to fail with preflightcors")
}
```