### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,13 +2,12 @@ on:
   pull_request:
     branches:
       - main
-      - v1.0
-      - v1.1
+      - v1.2.0
   push:
     branches:
       - main
-      - v1.0
       - v1.1
+      - v1.2.0
 
 name: Continuous Integration
 


### PR DESCRIPTION
Forgot to update the CI to include 1.2.0 when creating new branches. This fixes that for branch 1.2.0, so branches basing off of it should get the actions running again.