### PR TITLE
Uniformly treat an empty path as /

### DIFF
--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -8,7 +8,7 @@ import (
 // Return the next token from a path, starting at position last, and the position to use with the next call.
 // Next considers multiple consecutive slashes to act as a single slash.
 func Next(path string, last int) (string, int) {
-	if path == "" {
+	if path == "" && last == 0 {
 		path = "/"
 	}
 	if last+1 > len(path) {

--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -8,6 +8,9 @@ import (
 // Return the next token from a path, starting at position last, and the position to use with the next call.
 // Next considers multiple consecutive slashes to act as a single slash.
 func Next(path string, last int) (string, int) {
+	if path == "" {
+		path = "/"
+	}
 	if last+1 > len(path) {
 		return "", -1
 	}

--- a/pkg/path/path_test.go
+++ b/pkg/path/path_test.go
@@ -13,6 +13,10 @@ func TestNext(t *testing.T) {
 	if tk != "/" || next != -1 {
 		t.Errorf("Root path should return '/', -1, got '%s', %d", tk, next)
 	}
+	tk, next = Next(path, 10)
+	if tk != "" || next != -1 {
+		t.Errorf("Root path should return '', -1, got '%s', %d", tk, next)
+	}
 	path = "/path/to/file.txt"
 	expected := []string{"/path", "/to", "/file.txt"}
 	i := 0

--- a/pkg/path/path_test.go
+++ b/pkg/path/path_test.go
@@ -5,8 +5,8 @@ import "testing"
 func TestNext(t *testing.T) {
 	path := ""
 	tk, next := Next(path, 0)
-	if tk != "" || next != -1 {
-		t.Errorf("Empty path should return '', -1, got '%s', %d", tk, next)
+	if tk != "/" || next != -1 {
+		t.Errorf("Empty path should return '/', -1, got '%s', %d", tk, next)
 	}
 	path = "/"
 	tk, next = Next(path, 0)

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -166,6 +166,10 @@ func TestBasicRoutes(t *testing.T) {
 		WithMiddleware(testMiddleware),
 	)
 	s := httptest.NewServer(r)
+	runEvalRequest(t, s, "", reqGen(http.MethodGet), map[string]any{
+		"code": http.StatusOK,
+		"body": "root",
+	})
 	runEvalRequest(t, s, "/", reqGen(http.MethodGet), map[string]any{
 		"code": http.StatusOK,
 		"body": "root",

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -93,7 +93,12 @@ func reqGenHeaders(method string, headers http.Header) func(url, path string) *h
 
 func runEvalRequest(t *testing.T,
 	s *httptest.Server, path string, genReqTo func(string, string) *http.Request, expect map[string]any) {
-	name := strings.ReplaceAll(path, "/", "-")[1:]
+	var name string
+	if len(path) > 0 {
+		name = strings.ReplaceAll(path, "/", "-")[1:]
+	} else {
+		name = "empty"
+	}
 	t.Run(name, func(t *testing.T) {
 		req := genReqTo(s.URL, path)
 		res, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
Closes #80 to align with HTTP convention.