### PR TITLE
Thread safety + proper forward handling on handler-based middleware

### DIFF
--- a/pkg/middleware/handler.go
+++ b/pkg/middleware/handler.go
@@ -1,18 +1,42 @@
 package middleware
 
 import (
+	"context"
 	"net/http"
+	"sync"
+	"sync/atomic"
 )
+
+type idt bool
+
+var ids atomic.Int64
+var idp = &sync.Pool{
+	New: func() any {
+		id := ids.Add(1)
+		return id
+	},
+}
+var handling = make(map[int64]*http.Request)
+var hlock = &sync.RWMutex{}
 
 // Handler allows integration of traditional handler-chain-ware.
 func Handler(create func(next http.Handler) http.Handler) Middleware {
-	return func(w http.ResponseWriter, r *http.Request) *http.Request {
-		var out *http.Request
-		next := func(w http.ResponseWriter, req *http.Request) {
-			out = req
-		}
-		h := create(http.HandlerFunc(next))
-		h.ServeHTTP(w, r)
+	next := func(w http.ResponseWriter, req *http.Request) {
+		id := req.Context().Value(idt(true)).(int64)
+		hlock.Lock()
+		handling[id] = req
+		hlock.Unlock()
+	}
+	h := create(http.HandlerFunc(next))
+	return func(w http.ResponseWriter, req *http.Request) *http.Request {
+		id := idp.Get().(int64)
+		ctx := context.WithValue(req.Context(), idt(true), id)
+		req = req.WithContext(ctx)
+		h.ServeHTTP(w, req)
+		hlock.RLock()
+		out := handling[id]
+		hlock.RUnlock()
+		idp.Put(id)
 		return out
 	}
 }

--- a/pkg/middleware/handler.go
+++ b/pkg/middleware/handler.go
@@ -1,0 +1,18 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+// Handler allows integration of traditional handler-chain-ware.
+func Handler(create func(next http.Handler) http.Handler) Middleware {
+	return func(w http.ResponseWriter, r *http.Request) *http.Request {
+		var out *http.Request
+		next := func(w http.ResponseWriter, req *http.Request) {
+			out = req
+		}
+		h := create(http.HandlerFunc(next))
+		h.ServeHTTP(w, r)
+		return out
+	}
+}

--- a/pkg/middleware/handler_test.go
+++ b/pkg/middleware/handler_test.go
@@ -25,10 +25,10 @@ func getID(next http.Handler) http.Handler {
 	})
 }
 
-func TestHandler(t *testing.T) {
+func TestHandlerConcurrent(t *testing.T) {
 	mw := Handler(getID)
 	wg := &sync.WaitGroup{}
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < 1000; i++ {
 		wg.Add(1)
 		a := i
 		go func() {

--- a/pkg/middleware/handler_test.go
+++ b/pkg/middleware/handler_test.go
@@ -1,0 +1,110 @@
+package middleware
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+func noop(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		next.ServeHTTP(w, r)
+	})
+}
+
+func getID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if id, err := strconv.Atoi(r.Header.Get("X-Request-ID")); err == nil {
+			r = r.WithContext(context.WithValue(r.Context(), "Request-ID", id))
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func TestHandler(t *testing.T) {
+	mw := Handler(getID)
+	wg := &sync.WaitGroup{}
+	for i := 0; i < 10000; i++ {
+		wg.Add(1)
+		a := i
+		go func() {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.Header.Set("X-Request-ID", strconv.FormatInt(int64(a), 10))
+			req = mw(nil, req)
+			if req == nil {
+				t.Errorf("nil request")
+			} else if id := req.Context().Value("Request-ID"); id != a {
+				t.Error("expected", a, "got", id)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+func BenchmarkHandlerNoop(b *testing.B) {
+	mw := Handler(getID)
+	wg := &sync.WaitGroup{}
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 1; j++ {
+			wg.Add(1)
+			go func() {
+				req = mw(nil, req)
+				wg.Done()
+			}()
+			wg.Wait()
+		}
+	}
+}
+
+func BenchmarkHandlerID(b *testing.B) {
+	mw := Handler(getID)
+	wg := &sync.WaitGroup{}
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 1; j++ {
+			wg.Add(1)
+			a := j
+			go func() {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.Header.Set("X-Request-ID", strconv.FormatInt(int64(a), 10))
+				req = mw(nil, req)
+				if req == nil {
+					b.Errorf("nil request")
+				} else if id := req.Context().Value("Request-ID"); id != a {
+					b.Error("expected", a, "got", id)
+				}
+				wg.Done()
+			}()
+			wg.Wait()
+		}
+	}
+}
+
+func TestHandlerAsMiddleware(t *testing.T) {
+	expectedResponse := "Hello, world!"
+	create := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, expectedResponse)
+			next.ServeHTTP(w, r)
+		})
+	}
+	mw := Handler(create)
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/", nil)
+	rec := httptest.NewRecorder()
+	req = mw(rec, req)
+	if req == nil {
+		t.Errorf("request should be unchanged.")
+	}
+	if res := rec.Body.String(); res != "Hello, world!" {
+		t.Errorf(
+			"response should be \"%s\", got \"%s\"",
+			expectedResponse,
+			res,
+		)
+	}
+}

--- a/pkg/middleware/handler_test.go
+++ b/pkg/middleware/handler_test.go
@@ -26,7 +26,8 @@ func getID(next http.Handler) http.Handler {
 }
 
 func TestHandlerConcurrent(t *testing.T) {
-	mw := Handler(getID)
+	mw1 := Handler(noop)
+	mw2 := Handler(getID)
 	wg := &sync.WaitGroup{}
 	for i := 0; i < 1000; i++ {
 		wg.Add(1)
@@ -34,7 +35,8 @@ func TestHandlerConcurrent(t *testing.T) {
 		go func() {
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			req.Header.Set("X-Request-ID", strconv.FormatInt(int64(a), 10))
-			req = mw(nil, req)
+			req = mw1(nil, req)
+			req = mw2(nil, req)
 			if req == nil {
 				t.Errorf("nil request")
 			} else if id := req.Context().Value("Request-ID"); id != a {

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -129,11 +129,3 @@ func ExecuteMiddleware(mw []Middleware, w http.ResponseWriter, req *http.Request
 	}
 	return req
 }
-
-// Use an http.Handler as Middleware.
-func Handler(h http.Handler) Middleware {
-	return func(w http.ResponseWriter, r *http.Request) *http.Request {
-		h.ServeHTTP(w, r)
-		return r
-	}
-}

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -200,26 +199,5 @@ func TestFailure(t *testing.T) {
 	l, err = ParseLog(badlog)
 	if l != nil || err == nil {
 		t.Errorf("bad log should return nil, err, got %v, %s", l, err)
-	}
-}
-
-func TestHandlerAsMiddleware(t *testing.T) {
-	expectedResponse := "Hello, world!"
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintf(w, expectedResponse)
-	}
-	mw := Handler(http.HandlerFunc(handler))
-	req := httptest.NewRequest(http.MethodGet, "https://example.com/", nil)
-	rec := httptest.NewRecorder()
-	req = mw(rec, req)
-	if req == nil {
-		t.Errorf("request should be unchanged.")
-	}
-	if res := rec.Body.String(); res != "Hello, world!" {
-		t.Errorf(
-			"response should be \"%s\", got \"%s\"",
-			expectedResponse,
-			res,
-		)
 	}
 }


### PR DESCRIPTION
The previous assumption for `http.Handler` middleware was that we were assuming success, which is just not doable for lots of middleware. Fixing that posed a major issue, as Matcha operates on the assumption that control *always* returns to the router between middleware calls, so there wasn't a mechanism to handle forwarding of requests using the common Handler signature of `func(next http.Handler) http.Handler`.

There is now! There's a bit of overhead, but you can now use that signature with a `middleware.Handler` wrapper, and it works exactly as it should.