### PR TITLE
Mount/subrouters

### DIFF
--- a/bench/helpers.go
+++ b/bench/helpers.go
@@ -1,0 +1,50 @@
+package bench
+
+import (
+	"math/rand"
+	"net/http"
+	"strconv"
+
+	"github.com/cloudretic/matcha/pkg/cors"
+	"github.com/cloudretic/matcha/pkg/middleware"
+	"github.com/cloudretic/matcha/pkg/rctx"
+	"github.com/cloudretic/matcha/pkg/route/require"
+)
+
+type benchRoute struct {
+	method   string
+	path     string
+	testPath string
+	mws      []middleware.Middleware
+	rqs      []require.Required
+}
+
+func mwCORS() middleware.Middleware {
+	return cors.CORSMiddleware(&cors.AccessControlOptions{
+		AllowOrigin:  []string{"cloudretic.com"},
+		AllowMethods: []string{http.MethodGet, http.MethodPut, http.MethodDelete},
+		AllowHeaders: []string{"client_id"},
+	})
+}
+
+func mwID(w http.ResponseWriter, req *http.Request) *http.Request {
+	req.Header.Add("X-Matcha-Request-ID", strconv.FormatInt(rand.Int63(), 10))
+	return req
+}
+
+func mwIsUserParam(userParam string) middleware.Middleware {
+	return func(w http.ResponseWriter, r *http.Request) *http.Request {
+		user := rctx.GetParam(r.Context(), userParam)
+		is := r.Header.Get("X-Platform-User-ID")
+		if is != user {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("user " + is + " unauthorized"))
+			return nil
+		}
+		return r
+	}
+}
+
+var api_mws = []middleware.Middleware{mwCORS(), mwID}
+var api_mws_auth = []middleware.Middleware{mwIsUserParam("user"), mwCORS(), mwID}
+var api_rqs = []require.Required{require.Hosts("{.*}")}

--- a/bench/v2_test.go
+++ b/bench/v2_test.go
@@ -1,0 +1,127 @@
+package bench
+
+import (
+	"math/rand"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/cloudretic/matcha/pkg/route"
+	"github.com/cloudretic/matcha/pkg/router"
+)
+
+/*
+ * ===== MockBoards V2 API =====
+ *
+ * Use Case: MockBoards is a (fake) forum website setting up their API using Matcha. They're updating their API,
+ * but to maintain backwards compatibility, they're attaching v2 to a new endpoint. For the purposes of this benchmark,
+ * both APIs are the same--this is just a test of the performance of subrouters.
+ *
+ * ===== Using This Benchmark =====
+ *
+ * Run the API benchmark, and the offset benchmark from v1_test.go.
+ * For sequential results, subtract the offset from the X/op values.
+ * For concurrent results, divide the X/op values by 10, then subtract the offset.
+ */
+
+func choosev2() benchRoute {
+	idx := rand.Int() % len(apiRoutes)
+	choice := apiRoutes[idx]
+	v2 := rand.Int() % 2
+	if v2 == 0 {
+		choice.testPath = "/v2" + choice.testPath
+	}
+	return choice
+}
+
+// Just to check!
+func TestAPIv2(t *testing.T) {
+	v1 := router.Default()
+	v2 := router.Default()
+	for _, tr := range apiRoutes {
+		r := route.Declare(tr.method, tr.path)
+		for _, mw := range tr.mws {
+			r.Attach(mw)
+		}
+		for _, rq := range tr.rqs {
+			r.Require(rq)
+		}
+		v1.HandleRouteFunc(r, handleOK)
+		v2.HandleRouteFunc(r, handleOK)
+	}
+	v1.Mount("/v2", v2)
+	w := httptest.NewRecorder()
+	for i := 0; i < len(apiRoutes); i++ {
+		br := apiRoutes[i]
+		req := httptest.NewRequest(br.method, br.testPath, nil)
+		req.Header.Set("X-Platform-User-ID", "jnichols")
+		v1.ServeHTTP(w, req)
+		if w.Code != 200 {
+			t.Fatal(br.method, br.path, br.testPath, w.Code)
+		}
+		req = httptest.NewRequest(br.method, "/v2"+br.testPath, nil)
+		req.Header.Set("X-Platform-User-ID", "jnichols")
+		v1.ServeHTTP(w, req)
+		if w.Code != 200 {
+			t.Fatal(br.method, br.path, br.testPath, w.Code)
+		}
+	}
+}
+
+func BenchmarkAPIv2(b *testing.B) {
+	v1 := router.Default()
+	v2 := router.Default()
+	for _, tr := range apiRoutes {
+		r, err := route.New(tr.method, tr.path)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for _, mw := range tr.mws {
+			r.Attach(mw)
+		}
+		for _, rq := range tr.rqs {
+			r.Require(rq)
+		}
+		v1.HandleRouteFunc(r, handleOK)
+		v2.HandleRouteFunc(r, handleOK)
+	}
+	v1.Mount("/v2", v2)
+	b.Run(b.Name()+"-sequential", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			w := httptest.NewRecorder()
+			br := choosev2()
+			req := httptest.NewRequest(br.method, br.testPath, nil)
+			req.Header.Set("X-Platform-User-ID", "jnichols")
+			v1.ServeHTTP(w, req)
+		}
+	})
+	b.Run(b.Name()+"-concurrent-10", func(b *testing.B) {
+		wg := &sync.WaitGroup{}
+		for i := 0; i < b.N; i++ {
+			for i := 0; i < 10; i++ {
+				wg.Add(1)
+				go func() {
+					w := httptest.NewRecorder()
+					br := choosev2()
+					req := httptest.NewRequest(br.method, br.testPath, nil)
+					req.Header.Set("X-Platform-User-ID", "jnichols")
+					v1.ServeHTTP(w, req)
+					wg.Done()
+				}()
+			}
+			wg.Wait()
+		}
+	})
+}
+
+// BenchmarkOffset is used to calculate the performance offset of generating test values
+// for benchmarks.
+// This is important; creating new requests is expensive
+func BenchmarkOffsetv2(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = httptest.NewRecorder()
+		br := choosev2()
+		req := httptest.NewRequest(br.method, br.testPath, nil)
+		req.Header.Set("X-Platform-User-ID", "jnichols")
+	}
+}

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -7,6 +7,7 @@
     - [File Server with Partial Routes](#file-server-with-partial-routes)
     - [Note: Registration Order](#note-registration-order)
   - [Advanced Usage](#advanced-usage)
+    - [Mounting Subrouters](#mounting-subrouters)
     - [Customizing Routes with ConfigFuncs](#customizing-routes-with-configfuncs)
     - [Middleware](#middleware)
     - [Requirements](#requirements)
@@ -132,6 +133,26 @@ Implicitly deprioritizing some routes to skew towards exact matches causes two p
 We're working on ways to make routing more intuitive while avoiding these problems. In the meantime, we believe that strict registration order is the best way to go, so that you can always predict what Matcha will do with the instructions you give it.
 
 ## Advanced Usage
+
+### Mounting Subrouters
+
+In addition to `router.Handle` and similar functions, there is also `router.Mount`, which passes all requests to a path prefix through to the given handler. In this example, any request made to `localhost:3000/api` will go directly to the `api2` router.
+
+```go
+func main() {
+    api1 := router.Default()
+    api2 := router.Default()
+    // Register some handlers here.
+    api1.Mount("/v2", api2)
+    http.ListenAndServe(":3000", api1)
+}
+```
+
+Usage notes:
+
+- This automatically trims the given prefix, so routes in `api2` do *not* need to include `/v2` in their paths.
+- Mounting currently only supports static string paths.
+- The underlying path used for mounting is a partial path, and comes with all of the same caveats.
 
 ### Customizing Routes with ConfigFuncs
 

--- a/pkg/middleware/trim.go
+++ b/pkg/middleware/trim.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"net/http"
+	"strings"
+)
+
+func TrimPrefix(prefix string) Middleware {
+	return func(w http.ResponseWriter, r *http.Request) *http.Request {
+		path := r.URL.Path
+		if strings.Index(path, prefix) == 0 {
+			r.URL.Path = path[len(prefix):]
+		}
+		return r
+	}
+}
+
+func TrimPrefixStrict(prefix string, errMsg string) Middleware {
+	return func(w http.ResponseWriter, r *http.Request) *http.Request {
+		path := r.URL.Path
+		if strings.Index(path, prefix) == 0 {
+			r.URL.Path = path[len(prefix):]
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+			if errMsg == "" {
+				errMsg = "expected path prefix " + prefix
+			}
+			w.Write([]byte(errMsg))
+			return nil
+		}
+		return r
+	}
+}

--- a/pkg/middleware/trim.go
+++ b/pkg/middleware/trim.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 )
 
+// TrimPrefix trims a static prefix from the path of an inbound request.
+// If the prefix doesn't exist, the request is unmodified. If you want to reject requests
+// without the prefix, use TrimPrefixStrict.
 func TrimPrefix(prefix string) Middleware {
 	return func(w http.ResponseWriter, r *http.Request) *http.Request {
 		path := r.URL.Path
@@ -15,6 +18,9 @@ func TrimPrefix(prefix string) Middleware {
 	}
 }
 
+// TrimPrefixStrict trims a static prefix from the path of an inbound request.
+// If the prefix doesn't exist, the request is rejected and the errMsg is sent as a response.
+// An empty errMsg will generate an error message "expected path prefix [prefix]".
 func TrimPrefixStrict(prefix string, errMsg string) Middleware {
 	return func(w http.ResponseWriter, r *http.Request) *http.Request {
 		path := r.URL.Path

--- a/pkg/middleware/trim_test.go
+++ b/pkg/middleware/trim_test.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTrimPrefix(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/path/to/resource", nil)
+
+	reg := TrimPrefix("/path/to")
+	r1 := reg(w, req.Clone(context.Background()))
+	if r1.URL.Path != "/resource" {
+		t.Error("/resource", r1.URL.Path)
+	}
+	reg_wrong := TrimPrefix("/other/path")
+	r2 := reg_wrong(w, req.Clone(context.Background()))
+	if r2.URL.Path != "/path/to/resource" {
+		t.Error("/path/to/resource", r1.URL.Path)
+	}
+
+	strict := TrimPrefixStrict("/path/to", "")
+	r3 := strict(w, req.Clone(context.Background()))
+	if r3.URL.Path != "/resource" {
+		t.Error("/resource", r1.URL.Path)
+	}
+	strict_wrong := TrimPrefixStrict("/other/path", "")
+	r4 := strict_wrong(w, req.Clone(context.Background()))
+	if r4 != nil {
+		t.Error("expected nil request")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Error(http.StatusBadRequest, w.Code)
+	}
+}

--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -30,3 +30,16 @@ func Next(path string, last int) (string, int) {
 	}
 	return path[start:], -1
 }
+
+// MakePartial gives the partial equivalent of a route.
+// This effectively appends /+ to the path.
+func MakePartial(path string) string {
+	i := len(path) - 1
+	if path[i-1:] == "/+" {
+		return path
+	}
+	if path[i] == '/' {
+		return path + "+"
+	}
+	return path + "/+"
+}

--- a/pkg/path/path.go
+++ b/pkg/path/path.go
@@ -33,13 +33,15 @@ func Next(path string, last int) (string, int) {
 
 // MakePartial gives the partial equivalent of a route.
 // This effectively appends /+ to the path.
-func MakePartial(path string) string {
+func MakePartial(path string, param string) string {
+	if param != "" {
+		param = "[" + param + "]"
+	}
 	i := len(path) - 1
 	if path[i-1:] == "/+" {
-		return path
+		path = path[:i-1]
+	} else if path[i] == '/' {
+		path = path[:i]
 	}
-	if path[i] == '/' {
-		return path + "+"
-	}
-	return path + "/+"
+	return path + "/" + param + "+"
 }

--- a/pkg/path/path_test.go
+++ b/pkg/path/path_test.go
@@ -51,13 +51,16 @@ func BenchmarkNext(b *testing.B) {
 }
 
 func TestMakePartial(t *testing.T) {
-	if px := MakePartial("/hello"); px != "/hello/+" {
+	if px := MakePartial("/hello", ""); px != "/hello/+" {
 		t.Error("/hello/+", px)
 	}
-	if px := MakePartial("/hello/"); px != "/hello/+" {
+	if px := MakePartial("/hello/", ""); px != "/hello/+" {
 		t.Error("/hello/+", px)
 	}
-	if px := MakePartial("/hello/+"); px != "/hello/+" {
+	if px := MakePartial("/hello/+", ""); px != "/hello/+" {
 		t.Error("/hello/+", px)
+	}
+	if px := MakePartial("/hello", "next"); px != "/hello/[next]+" {
+		t.Error("/hello/[next]+", px)
 	}
 }

--- a/pkg/path/path_test.go
+++ b/pkg/path/path_test.go
@@ -49,3 +49,15 @@ func BenchmarkNext(b *testing.B) {
 		}
 	}
 }
+
+func TestMakePartial(t *testing.T) {
+	if px := MakePartial("/hello"); px != "/hello/+" {
+		t.Error("/hello/+", px)
+	}
+	if px := MakePartial("/hello/"); px != "/hello/+" {
+		t.Error("/hello/+", px)
+	}
+	if px := MakePartial("/hello/+"); px != "/hello/+" {
+		t.Error("/hello/+", px)
+	}
+}

--- a/pkg/rctx/rctx.go
+++ b/pkg/rctx/rctx.go
@@ -78,7 +78,14 @@ func ReturnRequestContext(req *http.Request) {
 // the key is passed to ctx.Value(paramKey(key)).
 func GetParam(ctx context.Context, key string) string {
 	if rctx, ok := ctx.(*Context); ok {
-		return rctx.params.get(paramKey(key))
+		v := rctx.params.get(paramKey(key))
+		if v != "" {
+			return v
+		} else if rctx.parent != nil {
+			ctx = rctx.parent
+		} else {
+			return ""
+		}
 	}
 	if val, ok := ctx.Value(paramKey(key)).(string); ok {
 		return val
@@ -138,7 +145,14 @@ func (ctx *Context) Err() error {
 // See interface context.Context.
 func (ctx *Context) Value(key any) any {
 	if pkey, ok := key.(paramKey); ok {
-		return ctx.params.get(pkey)
+		v := ctx.params.get(pkey)
+		if v != "" {
+			return v
+		} else if ctx.parent != nil {
+			return ctx.parent.Value(key)
+		} else {
+			return ""
+		}
 	} else if ctx.parent != nil {
 		return ctx.parent.Value(key)
 	} else {

--- a/pkg/rctx/rctx_test.go
+++ b/pkg/rctx/rctx_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
@@ -207,5 +208,47 @@ func TestOverrideContext(t *testing.T) {
 	}
 	if v := ctx.Value(paramKey("testParam")); v != "testCorrectValue" {
 		t.Errorf("got %s", v)
+	}
+}
+
+func TestNested(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/path", nil)
+	ctx := context.WithValue(req.Context(), paramKey("p3"), "v3")
+	req = req.WithContext(ctx)
+
+	req = PrepareRequestContext(req, 1)
+	err := SetParam(req.Context(), "p1", "v1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	req = PrepareRequestContext(req, 1)
+	err = SetParam(req.Context(), "p2", "v2")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if p1 := GetParam(req.Context(), "p1"); p1 != "v1" {
+		t.Error("v1", p1)
+	}
+	if p2 := GetParam(req.Context(), "p2"); p2 != "v2" {
+		t.Error("v2", p2)
+	}
+	if p3 := GetParam(req.Context(), "p3"); p3 != "v3" {
+		t.Error("v3", p3)
+	}
+	if p4 := GetParam(req.Context(), "p4"); p4 != "" {
+		t.Error("", p4)
+	}
+
+	// Test nil parents
+	rctx := req.Context().(*Context)
+	rctx.parent.(*Context).parent = nil
+	if p3 := GetParam(req.Context(), "p3"); p3 != "" {
+		t.Error("", p3)
+	}
+
+	rctx.parent = nil
+	if p1 := GetParam(req.Context(), "p1"); p1 != "" {
+		t.Error("", p1)
 	}
 }

--- a/pkg/route/default.go
+++ b/pkg/route/default.go
@@ -240,7 +240,6 @@ func (route *defaultRoute) MatchAndUpdateContext(req *http.Request) *http.Reques
 			break
 		}
 	}
-	//return req.WithContext(route.ctx)
 	return req
 }
 

--- a/pkg/router/default.go
+++ b/pkg/router/default.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/cloudretic/matcha/pkg/middleware"
@@ -113,9 +114,15 @@ func (rt *defaultRouter) Mount(rpath string, h http.Handler, methods ...string) 
 		}
 	}
 	trim := middleware.TrimPrefix(rpath)
-	rpath = path.MakePartial(rpath)
+	rpath = path.MakePartial(rpath, "")
+	validate := route.ConfigFunc(func(r route.Route) error {
+		if route.NumParams(r) > 0 {
+			return errors.New("invalid mount path; must be static strings only")
+		}
+		return nil
+	})
 	for _, method := range methods {
-		r, err := route.New(method, rpath)
+		r, err := route.New(method, rpath, validate)
 		if err != nil {
 			return err
 		}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -33,6 +33,11 @@ type Router interface {
 	// Handle a more complex path.
 	// If you're only using method+path, use Handle instead.
 	HandleRouteFunc(r route.Route, h http.HandlerFunc)
+	// Mount a handler at a path.
+	// Forwards all requests at path to the provided handler, optionally limited to a set
+	// of methods passed in the variadic methods parameter. Use this if you want to
+	// use your existing handler at a specific URI.
+	Mount(path string, h http.Handler, methods ...string) error
 	// Add a handler for any request that is not matched.
 	//
 	// Router implementations should define default behavior, and must allow user assignment of behavior.

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -458,4 +458,9 @@ func TestComposition(t *testing.T) {
 	if err == nil {
 		t.Error("expected failure due to route formatting")
 	}
+
+	err = api2.Mount("/api/[version]", api1)
+	if err == nil {
+		t.Error("expected error due to route formatting")
+	}
 }


### PR DESCRIPTION
Adds `router.Mount` to route all requests to a prefix to a subrouter. Additionally, adds some benchmarks, documentation, and related fixes + tools.

Closes #90 