### PR TITLE
Middleware update for v1.2.0

### DIFF
--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -16,18 +16,6 @@ import (
 // Returns an *http.Request; the middleware can set router params or reject a request by returning nil.
 type Middleware func(http.ResponseWriter, *http.Request) *http.Request
 
-// Returns a middleware that checks for the presence of a query parameter.
-func ExpectQueryParam(name string) Middleware {
-	return func(w http.ResponseWriter, r *http.Request) *http.Request {
-		if r.URL.Query().Has(name) {
-			return r
-		}
-		w.WriteHeader(http.StatusBadRequest)
-		fmt.Fprintf(w, "Missing query param: %s", name)
-		return nil
-	}
-}
-
 // The string used to indicate an absent origin in log entries.
 //
 // Origins take one of the following forms, so must not take any of these forms:

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -8,44 +8,6 @@ import (
 	"testing"
 )
 
-func TestExpectQueryParam(t *testing.T) {
-	t.Run("foo=bar", func(t *testing.T) {
-		m := ExpectQueryParam("foo")
-		r := httptest.NewRequest("GET", "http://example.com?foo=bar", nil)
-		w := httptest.NewRecorder()
-		if ExecuteMiddleware([]Middleware{m}, w, r) != r {
-			t.Error("ExpectQueryParam did not recognize foo was provided")
-		}
-	})
-
-	t.Run("foo=", func(t *testing.T) {
-		m := ExpectQueryParam("foo")
-		r := httptest.NewRequest("GET", "http://example.com?foo=", nil)
-		w := httptest.NewRecorder()
-		if ExecuteMiddleware([]Middleware{m}, w, r) != r {
-			t.Error("ExpectQueryParam did not recognize foo was provided")
-		}
-	})
-
-	t.Run("foo without equals sign", func(t *testing.T) {
-		m := ExpectQueryParam("foo")
-		r := httptest.NewRequest("GET", "http://example.com?foo", nil)
-		w := httptest.NewRecorder()
-		if ExecuteMiddleware([]Middleware{m}, w, r) != r {
-			t.Error("ExpectQueryParam should not have recognized foo was provided")
-		}
-	})
-
-	t.Run("foo absent", func(t *testing.T) {
-		m := ExpectQueryParam("foo")
-		r := httptest.NewRequest("GET", "http://example.com?bar=foo", nil)
-		w := httptest.NewRecorder()
-		if ExecuteMiddleware([]Middleware{m}, w, r) != nil {
-			t.Error("ExpectQueryParam should not have recognized foo was provided")
-		}
-	})
-}
-
 func TestLogRequests(t *testing.T) {
 	t.Run("log request with no origin", func(t *testing.T) {
 		var builder strings.Builder

--- a/pkg/middleware/spec.go
+++ b/pkg/middleware/spec.go
@@ -1,0 +1,103 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/cloudretic/matcha/pkg/regex"
+)
+
+// ExpectQueryParam checks for the presence of a query parameter.
+// Requests are rejected if the query parameter `name` is not present, or if the value
+// doesn't match the provided patterns. `patts` can be left empty to permit any or no
+// value assigned to `name`. Invalid patterns are silently discarded.
+//
+// See package Pattern for more details on pattern construction.
+func ExpectQueryParam(name string, patts ...string) Middleware {
+	var fs []func(v string) bool
+	if len(patts) == 0 {
+		fs = append(fs, func(_ string) bool {
+			return true
+		})
+	}
+	for _, patt := range patts {
+		value, isPatt, err := regex.CompilePattern(patt)
+		if err != nil {
+			continue
+		}
+		var f func(v string) bool
+		if isPatt {
+			f = value.Match
+		} else {
+			f = func(v string) bool {
+				return patt == v
+			}
+		}
+		fs = append(fs, f)
+	}
+	return func(w http.ResponseWriter, r *http.Request) *http.Request {
+		q := r.URL.Query()
+		if !q.Has(name) {
+			fmt.Fprintf(w, "invalid value for query param %s", name)
+			return nil
+		}
+		v := r.URL.Query().Get(name)
+		r.URL.Query()
+		for _, f := range fs {
+			if f(v) {
+				return r
+			}
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, "invalid value for query param %s", name)
+		return nil
+	}
+}
+
+// ExpectHeader checks for the presence of a header.
+// Requests are rejected if the header `name` is not present, or if the value
+// doesn't match the provided patterns, if any. `patts` can be left empty to permit
+// any value assigned to `name`, but headers must have a value to be permitted.
+// Invalid patterns are silently discarded.
+//
+// See package Pattern for more details on pattern construction.
+func ExpectHeader(name string, patts ...string) Middleware {
+	var fs []func(v string) bool
+	if len(patts) == 0 {
+		fs = append(fs, func(_ string) bool {
+			return true
+		})
+	}
+	for _, patt := range patts {
+		value, isPatt, err := regex.CompilePattern(patt)
+		if err != nil {
+			continue
+		}
+		var f func(v string) bool
+		if isPatt {
+			f = value.Match
+		} else {
+			f = func(v string) bool {
+				return patt == v
+			}
+		}
+		fs = append(fs, f)
+	}
+	return func(w http.ResponseWriter, r *http.Request) *http.Request {
+		h := r.Header
+		v := h.Get(name)
+		if v == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("invalid value for header " + name))
+			return nil
+		}
+		for _, f := range fs {
+			if f(v) {
+				return r
+			}
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("invalid value for header " + name))
+		return nil
+	}
+}

--- a/pkg/middleware/spec_test.go
+++ b/pkg/middleware/spec_test.go
@@ -1,0 +1,133 @@
+package middleware
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestExpectQueryParam(t *testing.T) {
+	t.Run("foo=bar", func(t *testing.T) {
+		m := ExpectQueryParam("foo", "bar")
+		r := httptest.NewRequest("GET", "http://example.com?foo=bar", nil)
+		w := httptest.NewRecorder()
+		if ExecuteMiddleware([]Middleware{m}, w, r) != r {
+			t.Error("ExpectQueryParam did not recognize foo was provided")
+		}
+		r = httptest.NewRequest("GET", "http://example.com?foo=baz", nil)
+		w = httptest.NewRecorder()
+		if ExecuteMiddleware([]Middleware{m}, w, r) != nil {
+			t.Error("ExpectQueryParam should not have recognized foo was provided")
+		}
+	})
+
+	t.Run("foo=bar,baz", func(t *testing.T) {
+		m := ExpectQueryParam("foo", "{bar|baz}", "{[}")
+		r := httptest.NewRequest("GET", "http://example.com?foo=bar", nil)
+		w := httptest.NewRecorder()
+		if ExecuteMiddleware([]Middleware{m}, w, r) != r {
+			t.Error("ExpectQueryParam did not recognize foo was provided")
+		}
+		r = httptest.NewRequest("GET", "http://example.com?foo=baz", nil)
+		w = httptest.NewRecorder()
+		if ExecuteMiddleware([]Middleware{m}, w, r) != r {
+			t.Error("ExpectQueryParam did not recognize foo was provided")
+		}
+		r = httptest.NewRequest("GET", "http://example.com?foo=bop", nil)
+		w = httptest.NewRecorder()
+		if ExecuteMiddleware([]Middleware{m}, w, r) != nil {
+			t.Error("ExpectQueryParam should not have recognized foo was provided")
+		}
+	})
+
+	t.Run("foo=", func(t *testing.T) {
+		m := ExpectQueryParam("foo")
+		r := httptest.NewRequest("GET", "http://example.com?foo=", nil)
+		w := httptest.NewRecorder()
+		if ExecuteMiddleware([]Middleware{m}, w, r) != r {
+			t.Error("ExpectQueryParam did not recognize foo was provided")
+		}
+	})
+
+	t.Run("foo without equals sign", func(t *testing.T) {
+		m := ExpectQueryParam("foo")
+		r := httptest.NewRequest("GET", "http://example.com?foo", nil)
+		w := httptest.NewRecorder()
+		if ExecuteMiddleware([]Middleware{m}, w, r) != r {
+			t.Error("ExpectQueryParam did not recognize foo was provided")
+		}
+	})
+
+	t.Run("foo absent", func(t *testing.T) {
+		m := ExpectQueryParam("foo")
+		r := httptest.NewRequest("GET", "http://example.com?bar=foo", nil)
+		w := httptest.NewRecorder()
+		if ExecuteMiddleware([]Middleware{m}, w, r) != nil {
+			t.Error("ExpectQueryParam should not have recognized foo was provided")
+		}
+	})
+}
+
+func TestExpectHeader(t *testing.T) {
+	t.Run("foo: bar", func(t *testing.T) {
+		m := ExpectHeader("foo", "bar")
+		r := httptest.NewRequest("GET", "http://example.com", nil)
+		r.Header.Set("foo", "bar")
+		w := httptest.NewRecorder()
+		if ExecuteMiddleware([]Middleware{m}, w, r) != r {
+			t.Error("ExpectHeader did not recognize foo was provided")
+		}
+		r = httptest.NewRequest("GET", "http://example.com", nil)
+		r.Header.Set("foo", "baz")
+		w = httptest.NewRecorder()
+		if ExecuteMiddleware([]Middleware{m}, w, r) != nil {
+			t.Error("ExpectHeader should not have recognized foo was provided")
+		}
+	})
+
+	t.Run("foo: bar,baz", func(t *testing.T) {
+		m := ExpectHeader("foo", "{bar|baz}", "{[}")
+		r := httptest.NewRequest("GET", "http://example.com", nil)
+		r.Header.Set("foo", "bar")
+		w := httptest.NewRecorder()
+		if ExecuteMiddleware([]Middleware{m}, w, r) != r {
+			t.Error("ExpectHeader did not recognize foo was provided")
+		}
+		r = httptest.NewRequest("GET", "http://example.com", nil)
+		r.Header.Set("foo", "baz")
+		w = httptest.NewRecorder()
+		if ExecuteMiddleware([]Middleware{m}, w, r) != r {
+			t.Error("ExpectHeader did not recognize foo was provided")
+		}
+		r = httptest.NewRequest("GET", "http://example.com", nil)
+		r.Header.Set("foo", "bop")
+		w = httptest.NewRecorder()
+		if ExecuteMiddleware([]Middleware{m}, w, r) != nil {
+			t.Error("ExpectHeader should not have recognized foo was provided")
+		}
+	})
+
+	t.Run("foo", func(t *testing.T) {
+		m := ExpectHeader("foo")
+		r := httptest.NewRequest("GET", "http://example.com", nil)
+		r.Header.Set("foo", "bar")
+		w := httptest.NewRecorder()
+		if ExecuteMiddleware([]Middleware{m}, w, r) != r {
+			t.Error("ExpectHeader should have recognized foo was provided")
+		}
+		r = httptest.NewRequest("GET", "http://example.com", nil)
+		r.Header.Set("foo", "")
+		w = httptest.NewRecorder()
+		if ExecuteMiddleware([]Middleware{m}, w, r) != nil {
+			t.Error("ExpectHeader should not have recognized foo was provided")
+		}
+	})
+
+	t.Run("foo absent", func(t *testing.T) {
+		m := ExpectHeader("foo")
+		r := httptest.NewRequest("GET", "http://example.com", nil)
+		w := httptest.NewRecorder()
+		if ExecuteMiddleware([]Middleware{m}, w, r) != nil {
+			t.Error("ExpectHeader should not have recognized foo was provided")
+		}
+	})
+}

--- a/pkg/route/config.go
+++ b/pkg/route/config.go
@@ -18,18 +18,16 @@ func CORSHeaders(aco *cors.AccessControlOptions) ConfigFunc {
 }
 
 // Attaches middleware to the route.
-func WithMiddleware(mw middleware.Middleware) ConfigFunc {
+func WithMiddleware(mws ...middleware.Middleware) ConfigFunc {
 	return func(r Route) error {
-		r.Attach(mw)
+		r.Attach(mws...)
 		return nil
 	}
 }
 
-func Require(vs ...require.Required) ConfigFunc {
+func Require(rs ...require.Required) ConfigFunc {
 	return func(r Route) error {
-		for _, v := range vs {
-			r.Require(v)
-		}
+		r.Require(rs...)
 		return nil
 	}
 }

--- a/pkg/route/default.go
+++ b/pkg/route/default.go
@@ -243,12 +243,12 @@ func (route *defaultRoute) MatchAndUpdateContext(req *http.Request) *http.Reques
 	return req
 }
 
-func (route *defaultRoute) Attach(mw middleware.Middleware) {
-	route.middleware = append(route.middleware, mw)
+func (route *defaultRoute) Attach(mws ...middleware.Middleware) {
+	route.middleware = append(route.middleware, mws...)
 }
 
-func (route *defaultRoute) Require(v require.Required) {
-	route.required = append(route.required, v)
+func (route *defaultRoute) Require(rs ...require.Required) {
+	route.required = append(route.required, rs...)
 }
 
 func (route *defaultRoute) Middleware() []middleware.Middleware {

--- a/pkg/route/partial.go
+++ b/pkg/route/partial.go
@@ -217,12 +217,12 @@ func (route *partialRoute) MatchAndUpdateContext(req *http.Request) *http.Reques
 	return req
 }
 
-func (route *partialRoute) Attach(m middleware.Middleware) {
-	route.middleware = append(route.middleware, m)
+func (route *partialRoute) Attach(mws ...middleware.Middleware) {
+	route.middleware = append(route.middleware, mws...)
 }
 
-func (route *partialRoute) Require(v require.Required) {
-	route.required = append(route.required, v)
+func (route *partialRoute) Require(rs ...require.Required) {
+	route.required = append(route.required, rs...)
 }
 
 func (route *partialRoute) Middleware() []middleware.Middleware {

--- a/pkg/route/route.go
+++ b/pkg/route/route.go
@@ -38,11 +38,11 @@ type Route interface {
 	// Attach middleware to the route.
 	//
 	// Middleware cannot be removed from a router once it is added.
-	Attach(mw middleware.Middleware)
+	Attach(mws ...middleware.Middleware)
 	// Attach a validator to the route.
 	//
 	// Validators cannot be removed from a router once they are added.
-	Require(v require.Required)
+	Require(rs ...require.Required)
 	// Get the middleware attached to the route.
 	Middleware() []middleware.Middleware
 	// Get the validators attached to the route.

--- a/pkg/router/config.go
+++ b/pkg/router/config.go
@@ -83,9 +83,9 @@ func PreflightCORS(expr string, aco *cors.AccessControlOptions) ConfigFunc {
 }
 
 // Attach generic middleware to the Router
-func WithMiddleware(mw middleware.Middleware) ConfigFunc {
+func WithMiddleware(mws ...middleware.Middleware) ConfigFunc {
 	return func(rt Router) error {
-		rt.Attach(mw)
+		rt.Attach(mws...)
 		return nil
 	}
 }

--- a/pkg/router/default.go
+++ b/pkg/router/default.go
@@ -34,8 +34,8 @@ func Default() *defaultRouter {
 // Attach middleware to the router.
 //
 // See interface Router.
-func (rt *defaultRouter) Attach(mw middleware.Middleware) {
-	rt.mws = append(rt.mws, mw)
+func (rt *defaultRouter) Attach(mws ...middleware.Middleware) {
+	rt.mws = append(rt.mws, mws...)
 }
 
 // Add a route to the router.

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -14,7 +14,7 @@ type Router interface {
 	// Attach middleware to the router.
 	//
 	// Router implementations must run all attached middleware on all incoming requests.
-	Attach(mw middleware.Middleware)
+	Attach(mw ...middleware.Middleware)
 	// Add a route to the router.
 	//
 	// AddRoute was deprecated in v1.2.0. Use HandleRoute instead.


### PR DESCRIPTION
- Middleware attachment now accepts a variadic list rather than a single parameter
- New middleware for expecting/validating query parameters and headers
- Query parameters can match any or no value, or against a series of strings/Patterns
- Headers can match any (but not no) value, or against a series of strings/Patterns