### PR TITLE
Reserved parameters + fullpath

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,13 +2,11 @@ on:
   pull_request:
     branches:
       - main
-      - v1.2.0
+      - v?.?.?
   push:
     branches:
       - main
-      - v1.1
-      - v1.2.0
-      - v1.3.0
+      - v?.?.?
 
 name: Continuous Integration
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,11 +2,11 @@ on:
   pull_request:
     branches:
       - main
-      - v?.?.?
+      - v1.3.0
   push:
     branches:
       - main
-      - v?.?.?
+      - v1.3.0
 
 name: Continuous Integration
 

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -35,9 +35,7 @@ You can designate a wildcard parameter using a part surrounded by square bracket
 r, err := route.New(http.MethodGet, "/devices/[deviceName]/data")
 ```
 
-Some wildcards are *reserved* by Matcha; you can't use them in request URLs, as they have a designated use as request parameters. These are:
-
-- `fullpath`
+Wildcards starting with `matcha_` are reserved for use by Matcha. This isn't strictly enforced, but implementing something this way may lead to undesirable behavior down the line. You've been warned.
 
 ### Regex
 

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -35,6 +35,10 @@ You can designate a wildcard parameter using a part surrounded by square bracket
 r, err := route.New(http.MethodGet, "/devices/[deviceName]/data")
 ```
 
+Some wildcards are *reserved* by Matcha; you can't use them in request URLs, as they have a designated use as request parameters. These are:
+
+- `fullpath`
+
 ### Regex
 
 You can design routes to reject any requests that have improper formatting on a part-by-part basis by using a part surrounded by squiggly brackets, `{}`. You can also combine this with a wildcard to validate route parameters. Building on the following example, if IDs are specifically a string of four lowercase letters or digits in any order:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -147,11 +147,7 @@ func main() {
 }
 ```
 
-Usage notes:
-
-- This automatically trims the given prefix, so routes in `api2` do *not* need to include `/v2` in their paths.
-- Mounting currently only supports static string paths.
-- The underlying path used for mounting is a partial path, and comes with all of the same caveats.
+This serves all incoming requests to `/v2/+` with the prefix trimmed, so `api2` can assume that inbound requests do not start their paths with `/v2`. If you need to know the original path of the request as received by the root router, you can use `rctx.GetParam(req.Context(), rctx.FULLPATH)`.
 
 ### Complex Routes
 

--- a/pkg/rctx/params.go
+++ b/pkg/rctx/params.go
@@ -47,7 +47,7 @@ func (rps *routeParams) get(key paramKey) string {
 }
 
 func (rps *routeParams) set(in *Context, key paramKey, value string) error {
-	if reserved, err := rps.reserved.set(in, key, value); reserved {
+	if reserved, err := rps.reserved.set(in.parent, key, value); reserved {
 		return err
 	}
 	idx := rps.head

--- a/pkg/rctx/rctx.go
+++ b/pkg/rctx/rctx.go
@@ -43,7 +43,7 @@ func new(parent context.Context, maxParams int) *Context {
 func PrepareRequestContext(req *http.Request, maxParams int) *http.Request {
 	rctx := new(req.Context(), maxParams)
 	if req.URL != nil {
-		rctx.params.set(rctx, reserved_fullpath, req.URL.Path)
+		rctx.params.set(rctx, key_reserved_fullpath, req.URL.Path)
 	}
 	return req.WithContext(rctx)
 }

--- a/pkg/rctx/rctx.go
+++ b/pkg/rctx/rctx.go
@@ -42,7 +42,9 @@ func new(parent context.Context, maxParams int) *Context {
 // PrepareRequestContext prepares the context of a request for matching.
 func PrepareRequestContext(req *http.Request, maxParams int) *http.Request {
 	rctx := new(req.Context(), maxParams)
-	rctx.params.set(rctx, reserved_fullpath, req.URL.Path)
+	if req.URL != nil {
+		rctx.params.set(rctx, reserved_fullpath, req.URL.Path)
+	}
 	return req.WithContext(rctx)
 }
 

--- a/pkg/rctx/rctx.go
+++ b/pkg/rctx/rctx.go
@@ -42,6 +42,7 @@ func new(parent context.Context, maxParams int) *Context {
 // PrepareRequestContext prepares the context of a request for matching.
 func PrepareRequestContext(req *http.Request, maxParams int) *http.Request {
 	rctx := new(req.Context(), maxParams)
+	rctx.params.set(rctx, reserved_fullpath, req.URL.Path)
 	return req.WithContext(rctx)
 }
 
@@ -65,6 +66,7 @@ func ReturnRequestContext(req *http.Request) {
 			rctx.params.rps[i].key = ""
 			rctx.params.rps[i].value = ""
 		}
+		rctx.params.reserved.reset()
 		rctxPool.Put(rctx)
 	}
 }
@@ -99,7 +101,7 @@ func GetParam(ctx context.Context, key string) string {
 // the maximum number of params.
 func SetParam(ctx context.Context, key, value string) error {
 	if rctx, ok := ctx.(*Context); ok {
-		return rctx.params.set(paramKey(key), value)
+		return rctx.params.set(rctx, paramKey(key), value)
 	}
 	return errors.New("cannot SetParam on non-rctx Context")
 }

--- a/pkg/rctx/rctx_bench_test.go
+++ b/pkg/rctx/rctx_bench_test.go
@@ -2,6 +2,7 @@ package rctx
 
 import (
 	"net/http"
+	"net/url"
 	"testing"
 )
 
@@ -15,12 +16,17 @@ func BenchmarkNewParams(b *testing.B) {
 }
 
 func BenchmarkPrepare(b *testing.B) {
-	req := &http.Request{}
+	url, _ := url.Parse("/")
+	req := &http.Request{
+		URL: url,
+	}
 	for i := 0; i < b.N; i++ {
 		req = PrepareRequestContext(req, DefaultMaxParams)
 		//req = req.WithContext(context.Background())
 		// req = req.WithContext(context.Background())
-		req = &http.Request{}
+		req = &http.Request{
+			URL: url,
+		}
 	}
 }
 

--- a/pkg/rctx/rctx_test.go
+++ b/pkg/rctx/rctx_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"sync"
 	"testing"
 	"time"
@@ -169,10 +168,6 @@ func TestImplementContext(t *testing.T) {
 	cancel()
 	// Test nil parent
 	req = &http.Request{}
-	req.URL, err = url.Parse("/")
-	if err != nil {
-		t.Fatal(err)
-	}
 	req = PrepareRequestContext(req, DefaultMaxParams)
 	if ctx, ok := req.Context().(*Context); !ok {
 		t.Fatal("need *rctx.Context")

--- a/pkg/rctx/rctx_test.go
+++ b/pkg/rctx/rctx_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync"
 	"testing"
 	"time"
@@ -168,6 +169,10 @@ func TestImplementContext(t *testing.T) {
 	cancel()
 	// Test nil parent
 	req = &http.Request{}
+	req.URL, err = url.Parse("/")
+	if err != nil {
+		t.Fatal(err)
+	}
 	req = PrepareRequestContext(req, DefaultMaxParams)
 	if ctx, ok := req.Context().(*Context); !ok {
 		t.Fatal("need *rctx.Context")

--- a/pkg/rctx/reserved.go
+++ b/pkg/rctx/reserved.go
@@ -1,5 +1,6 @@
 package rctx
 
+const FULLPATH = string("fullpath")
 const reserved_fullpath = paramKey("fullpath")
 
 type reservedParams struct {

--- a/pkg/rctx/reserved.go
+++ b/pkg/rctx/reserved.go
@@ -1,0 +1,42 @@
+package rctx
+
+const reserved_fullpath = paramKey("fullpath")
+
+type reservedParams struct {
+	fullpath string
+}
+
+// get gets a reserved rctx param.
+// Returns the value, and true if key is reserved.
+func (rps *reservedParams) get(key paramKey) (string, bool) {
+	switch string(key) {
+	case "fullpath":
+		return rps.fullpath, true
+	default:
+		return "", false
+	}
+}
+
+// set sets a reserved rctx param.
+// Returns true if the key is reserved.
+func (rps *reservedParams) set(in *Context, key paramKey, value string) (bool, error) {
+	switch key {
+	case reserved_fullpath:
+		if rps.fullpath == "" {
+			if orig := in.parent.Value(reserved_fullpath); orig != nil && orig.(string) != "" {
+				value = orig.(string)
+			}
+			rps.fullpath = value
+		}
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+// reset resets the reserved params.
+// Some reserved params have special behavior when set multiple times; this sets back to
+// default values so that behavior can be replicated on pooled context.
+func (rps *reservedParams) reset() {
+	rps.fullpath = ""
+}

--- a/pkg/rctx/reserved.go
+++ b/pkg/rctx/reserved.go
@@ -1,18 +1,23 @@
 package rctx
 
-const FULLPATH = string("fullpath")
-const reserved_fullpath = paramKey("fullpath")
+const FULLPATH = string("matcha_fullpath")
+const key_reserved_fullpath = paramKey(FULLPATH)
+const MOUNTPROXYTO = string("matcha_mountProxyTo")
+const key_reserved_mountProxyTo = paramKey(MOUNTPROXYTO)
 
 type reservedParams struct {
-	fullpath string
+	fullpath     string
+	mountProxyTo string
 }
 
 // get gets a reserved rctx param.
 // Returns the value, and true if key is reserved.
 func (rps *reservedParams) get(key paramKey) (string, bool) {
-	switch string(key) {
-	case "fullpath":
+	switch key {
+	case key_reserved_fullpath:
 		return rps.fullpath, true
+	case key_reserved_mountProxyTo:
+		return rps.mountProxyTo, true
 	default:
 		return "", false
 	}
@@ -22,13 +27,16 @@ func (rps *reservedParams) get(key paramKey) (string, bool) {
 // Returns true if the key is reserved.
 func (rps *reservedParams) set(in *Context, key paramKey, value string) (bool, error) {
 	switch key {
-	case reserved_fullpath:
+	case key_reserved_fullpath:
 		if rps.fullpath == "" {
-			if orig := in.parent.Value(reserved_fullpath); orig != nil && orig.(string) != "" {
+			if orig := in.parent.Value(key_reserved_fullpath); orig != nil && orig.(string) != "" {
 				value = orig.(string)
 			}
 			rps.fullpath = value
 		}
+		return true, nil
+	case key_reserved_mountProxyTo:
+		rps.mountProxyTo = value
 		return true, nil
 	default:
 		return false, nil
@@ -40,4 +48,5 @@ func (rps *reservedParams) set(in *Context, key paramKey, value string) (bool, e
 // default values so that behavior can be replicated on pooled context.
 func (rps *reservedParams) reset() {
 	rps.fullpath = ""
+	rps.mountProxyTo = ""
 }

--- a/pkg/rctx/reserved.go
+++ b/pkg/rctx/reserved.go
@@ -1,5 +1,9 @@
 package rctx
 
+import (
+	"context"
+)
+
 const FULLPATH = string("matcha_fullpath")
 const key_reserved_fullpath = paramKey(FULLPATH)
 const MOUNTPROXYTO = string("matcha_mountProxyTo")
@@ -25,14 +29,17 @@ func (rps *reservedParams) get(key paramKey) (string, bool) {
 
 // set sets a reserved rctx param.
 // Returns true if the key is reserved.
-func (rps *reservedParams) set(in *Context, key paramKey, value string) (bool, error) {
+func (rps *reservedParams) set(parent context.Context, key paramKey, value string) (bool, error) {
 	switch key {
 	case key_reserved_fullpath:
 		if rps.fullpath == "" {
-			if orig := in.parent.Value(key_reserved_fullpath); orig != nil && orig.(string) != "" {
-				value = orig.(string)
+			if parent == nil {
+				rps.fullpath = value
+			} else if orig := parent.Value(key_reserved_fullpath); orig != nil && orig.(string) != "" {
+				rps.fullpath = orig.(string)
+			} else {
+				rps.fullpath = value
 			}
-			rps.fullpath = value
 		}
 		return true, nil
 	case key_reserved_mountProxyTo:

--- a/pkg/rctx/reserved_test.go
+++ b/pkg/rctx/reserved_test.go
@@ -1,0 +1,45 @@
+package rctx
+
+import (
+	"context"
+	"testing"
+)
+
+func TestReserved(t *testing.T) {
+	// Full path should set exactly once each reset
+	rps := reservedParams{}
+	ctx := context.Background()
+	rps.set(ctx, key_reserved_fullpath, "/test/path")
+	if fp, reserved := rps.get(key_reserved_fullpath); !reserved || fp != "/test/path" {
+		t.Error(fp, reserved)
+	}
+	rps.set(ctx, key_reserved_fullpath, "/other/test/path")
+	if fp, reserved := rps.get(key_reserved_fullpath); !reserved || fp != "/test/path" {
+		t.Error(fp, reserved)
+	}
+	rps.reset()
+	rps.set(nil, key_reserved_fullpath, "/other/test/path")
+	if fp, reserved := rps.get(key_reserved_fullpath); !reserved || fp != "/other/test/path" {
+		t.Error(fp, reserved)
+	}
+	// A parent context with this value should be accessed instead of the child context.
+	ctx = context.WithValue(ctx, key_reserved_fullpath, "/parent/path")
+	rps.reset()
+	rps.set(ctx, key_reserved_fullpath, "/test/path")
+	if fp, reserved := rps.get(key_reserved_fullpath); !reserved || fp != "/parent/path" {
+		t.Error(fp, reserved)
+	}
+	// Mount proxy-to path should be freely settable
+	rps.set(ctx, key_reserved_mountProxyTo, "/test/path")
+	if fp, reserved := rps.get(key_reserved_mountProxyTo); !reserved || fp != "/test/path" {
+		t.Error(fp, reserved)
+	}
+	rps.set(ctx, key_reserved_mountProxyTo, "/other/test/path")
+	if fp, reserved := rps.get(key_reserved_mountProxyTo); !reserved || fp != "/other/test/path" {
+		t.Error(fp, reserved)
+	}
+	// Other keys should be ignored
+	if reserved, err := rps.set(ctx, paramKey("other-key"), "anyvalue"); reserved || err != nil {
+		t.Error(reserved, err)
+	}
+}


### PR DESCRIPTION
This PR introduces 3 things:

- Context parameters beginning with `matcha_` are _reserved_ and should not be used as URI params. They have special meaning internal to Matcha.
- Param `rctx.FULLPATH` is now the full path of a request as first received by any Matcha router. This means that when mounting subrouters onto a Matcha router, you can access the full request path through `rctx.GetParam(req.Context(), rctx.FULLPATH)` rather than using a workaround.
- Param `rctx.MOUNTPROXYTO` is now the most recent path of a request proxied to a mounted handler/subrouter. This has limited use for users, but means that you can mount handlers onto routes with URI params now.