### PR TITLE
Implement request id middleware

### DIFF
--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -4,7 +4,6 @@
 package middleware
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,8 +15,6 @@ import (
 //
 // Returns an *http.Request; the middleware can set router params or reject a request by returning nil.
 type Middleware func(http.ResponseWriter, *http.Request) *http.Request
-
-type RequestIDGenerator func() string
 
 // The string used to indicate an absent origin in log entries.
 //
@@ -36,19 +33,6 @@ const OriginAbsent = "-"
 func LogRequests(w io.Writer) Middleware {
 	return func(_ http.ResponseWriter, r *http.Request) *http.Request {
 		logRequest(w, r)
-		return r
-	}
-}
-
-func RequestID(generator RequestIDGenerator, key string, isContext bool) Middleware {
-	return func(_ http.ResponseWriter, r *http.Request) *http.Request {
-		if isContext {
-			ctx := context.WithValue(r.Context(), key, generator())
-			return r.WithContext(ctx)
-		}
-
-		r.Header.Add(key, generator())
-
 		return r
 	}
 }

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -4,6 +4,7 @@
 package middleware
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -15,6 +16,8 @@ import (
 //
 // Returns an *http.Request; the middleware can set router params or reject a request by returning nil.
 type Middleware func(http.ResponseWriter, *http.Request) *http.Request
+
+type RequestIDGenerator func() string
 
 // The string used to indicate an absent origin in log entries.
 //
@@ -33,6 +36,19 @@ const OriginAbsent = "-"
 func LogRequests(w io.Writer) Middleware {
 	return func(_ http.ResponseWriter, r *http.Request) *http.Request {
 		logRequest(w, r)
+		return r
+	}
+}
+
+func RequestID(generator RequestIDGenerator, key string, isContext bool) Middleware {
+	return func(_ http.ResponseWriter, r *http.Request) *http.Request {
+		if isContext {
+			ctx := context.WithValue(r.Context(), key, generator())
+			return r.WithContext(ctx)
+		}
+
+		r.Header.Add(key, generator())
+
 		return r
 	}
 }

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -8,6 +8,57 @@ import (
 	"testing"
 )
 
+func TestRequestId(t *testing.T) {
+	t.Run("request id is added to header", func(t *testing.T) {
+		w := httptest.NewRecorder()
+
+		g := func() string {
+			return "test_value"
+		}
+
+		mw := RequestID(g, "X-Request-ID", false)
+
+		req := httptest.NewRequest(http.MethodGet, "https://example.com/", nil)
+
+		req = ExecuteMiddleware([]Middleware{mw}, w, req)
+
+		if req == nil {
+			t.Fatal("request was nil, should be unchanged")
+		}
+
+		h := req.Header.Get("X-Request-ID")
+
+		if h != "test_value" {
+			t.Errorf("expected header value to be test_value, got %s", h)
+		}
+
+	})
+
+	t.Run("request id is added to context", func(t *testing.T) {
+		w := httptest.NewRecorder()
+
+		g := func() string {
+			return "test_value"
+		}
+
+		mw := RequestID(g, "X-Request-ID", true)
+
+		req := httptest.NewRequest(http.MethodGet, "https://example.com/", nil)
+
+		req = ExecuteMiddleware([]Middleware{mw}, w, req)
+
+		if req == nil {
+			t.Fatal("request was nil, should be unchanged")
+		}
+
+		cv := req.Context().Value("X-Request-ID")
+
+		if cv != "test_value" {
+			t.Errorf("expected context value to be test_value, got %s", cv)
+		}
+	})
+}
+
 func TestLogRequests(t *testing.T) {
 	t.Run("log request with no origin", func(t *testing.T) {
 		var builder strings.Builder

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -51,7 +51,7 @@ func TestRequestId(t *testing.T) {
 			t.Fatal("request was nil, should be unchanged")
 		}
 
-		cv := req.Context().Value("X-Request-ID")
+		cv := req.Context().Value(requestIdKey("X-Request-ID"))
 
 		if cv != "test_value" {
 			t.Errorf("expected context value to be test_value, got %s", cv)

--- a/pkg/middleware/requestid.go
+++ b/pkg/middleware/requestid.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+)
+
+type RequestIDGenerator func() string
+
+type requestIdKey string
+
+func RequestID(generator RequestIDGenerator, key string, isContext bool) Middleware {
+	return func(_ http.ResponseWriter, r *http.Request) *http.Request {
+		if isContext {
+			ctx := context.WithValue(r.Context(), requestIdKey(key), generator())
+			return r.WithContext(ctx)
+		}
+
+		r.Header.Add(key, generator())
+
+		return r
+	}
+}


### PR DESCRIPTION
# Changes

- i added a type for the generator function
- i pass 3 params in the middleware `generator function,key for the header or context and a boolean value to check if we should set the request id in context or header`
- i wrote some basic tests to check if the request id is being set successfully in the header or context

I was thinking to make the generator function return type a generic currently its a string type, let me know if there are any changes thanks!

Closes #106 